### PR TITLE
[IOS-5813]Fix nurl not triggered issue

### DIFF
--- a/Vungle/VungleAdapter/ALVungleMediationAdapter.m
+++ b/Vungle/VungleAdapter/ALVungleMediationAdapter.m
@@ -139,7 +139,6 @@ static MAAdapterInitializationStatus ALVungleIntializationStatus = NSIntegerMin;
 {
     if ( self.adView )
     {
-        // Note: Not calling this for now because it clears pre-loaded/cached ad view ads as well.
         if ( self.bidResponse )
         {
             [[VungleSDK sharedSDK] finishDisplayingAd: self.placementIdentifier adMarkup: self.bidResponse];

--- a/Vungle/VungleAdapter/ALVungleMediationAdapter.m
+++ b/Vungle/VungleAdapter/ALVungleMediationAdapter.m
@@ -192,23 +192,8 @@ static MAAdapterInitializationStatus ALVungleIntializationStatus = NSIntegerMin;
                                delegate: delegate
                  forPlacementIdentifier: self.placementIdentifier];
     
-    if ( isBiddingAd )
-    {
-        if ( [[VungleSDK sharedSDK] isAdCachedForPlacementID: self.placementIdentifier adMarkup: bidResponse] )
-        {
-            [self log: @"Interstitial ad loaded"];
-            [delegate didLoadInterstitialAd];
-            
-            return;
-        }
-    }
-    else if ( [[VungleSDK sharedSDK] isAdCachedForPlacementID: self.placementIdentifier] )
-    {
-        [self log: @"Interstitial ad loaded"];
-        [delegate didLoadInterstitialAd];
-        
-        return;
-    }
+    // Not allowed to skip load ad even if the ad is cached.
+    // That will cause nurl missing issue.
     
     NSError *error;
     BOOL isLoaded = [self loadAdForParameters: parameters
@@ -283,23 +268,8 @@ static MAAdapterInitializationStatus ALVungleIntializationStatus = NSIntegerMin;
                           delegate: delegate
             forPlacementIdentifier: self.placementIdentifier];
     
-    if ( isBiddingAd )
-    {
-        if ( [[VungleSDK sharedSDK] isAdCachedForPlacementID: self.placementIdentifier adMarkup: bidResponse] )
-        {
-            [self log: @"App open ad loaded"];
-            [delegate didLoadAppOpenAd];
-            
-            return;
-        }
-    }
-    else if ( [[VungleSDK sharedSDK] isAdCachedForPlacementID: self.placementIdentifier] )
-    {
-        [self log: @"App open ad loaded"];
-        [delegate didLoadAppOpenAd];
-        
-        return;
-    }
+    // Not allowed to skip load ad even if the ad is cached.
+    // That will cause nurl missing issue.
     
     NSError *error;
     BOOL isLoaded = [self loadAdForParameters: parameters
@@ -374,23 +344,8 @@ static MAAdapterInitializationStatus ALVungleIntializationStatus = NSIntegerMin;
                            delegate: delegate
              forPlacementIdentifier: self.placementIdentifier];
     
-    if ( isBiddingAd )
-    {
-        if ( [[VungleSDK sharedSDK] isAdCachedForPlacementID: self.placementIdentifier adMarkup: bidResponse] )
-        {
-            [self log: @"Rewarded ad loaded"];
-            [delegate didLoadRewardedAd];
-            
-            return;
-        }
-    }
-    else if ( [[VungleSDK sharedSDK] isAdCachedForPlacementID: self.placementIdentifier] )
-    {
-        [self log: @"Rewarded ad loaded"];
-        [delegate didLoadRewardedAd];
-        
-        return;
-    }
+    // Not allowed to skip load ad even if the ad is cached.
+    // That will cause nurl missing issue.
     
     NSError *error;
     BOOL isLoaded = [self loadAdForParameters: parameters
@@ -472,26 +427,8 @@ static MAAdapterInitializationStatus ALVungleIntializationStatus = NSIntegerMin;
     
     [[VungleSDK sharedSDK] disableBannerRefresh];
     
-    VungleAdSize adSize = [ALVungleMediationAdapter vungleBannerAdSizeFromFormat: adFormat];
-    if ( isBiddingAd )
-    {
-        if ( [[VungleSDK sharedSDK] isAdCachedForPlacementID: self.placementIdentifier adMarkup: bidResponse]
-            || [[VungleSDK sharedSDK] isAdCachedForPlacementID: self.placementIdentifier adMarkup: bidResponse withSize: adSize] )
-        {
-            [self showAdViewAdForParameters: parameters
-                                   adFormat: adFormat
-                                  andNotify: delegate];
-            return;
-        }
-    }
-    else if ( [[VungleSDK sharedSDK] isAdCachedForPlacementID: self.placementIdentifier]
-             || [[VungleSDK sharedSDK] isAdCachedForPlacementID: self.placementIdentifier withSize: adSize] )
-    {
-        [self showAdViewAdForParameters: parameters
-                               adFormat: adFormat
-                              andNotify: delegate];
-        return;
-    }
+    // Not allowed to skip load ad even if the ad is cached.
+    // That will cause nurl missing issue.
     
     [self loadAdViewAdForParameters:parameters adFormat:adFormat adFormatLabel:adFormatLabel andNotify:delegate completion:^(NSString * placementID) {
         self.router.adViewAdLoadCompletionBlock = nil;


### PR DESCRIPTION
Before loading an ad, the MAX Adapter will check if the ad is cached. If the ad is cached, the MAX Adapter will not call the load ad API. This will cause the issue that the nurl is not be triggered. This issue happens in both bidding and waterfall ads.
nurl must be triggered after calling load ad API explicitly.

IOS-5813