### PR TITLE
Re-init SDK on load api if SDK is not initialized and error code mapping

### DIFF
--- a/Vungle/VungleAdapter/ALVungleMediationAdapter.m
+++ b/Vungle/VungleAdapter/ALVungleMediationAdapter.m
@@ -9,7 +9,7 @@
 #import "ALVungleMediationAdapter.h"
 #import <VungleAdsSDK/VungleAdsSDK.h>
 
-#define ADAPTER_VERSION @"7.2.2.0"
+#define ADAPTER_VERSION @"7.3.0.0"
 
 @interface ALVungleMediationAdapterInterstitialAdDelegate : NSObject <VungleInterstitialDelegate>
 @property (nonatomic,   weak) ALVungleMediationAdapter *parentAdapter;
@@ -209,7 +209,7 @@ static MAAdapterInitializationStatus ALVungleIntializationStatus = NSIntegerMin;
     {
         [self log: @"Vungle SDK not successfully initialized: failing interstitial ad load..."];
         [delegate didFailToLoadInterstitialAdWithError: MAAdapterError.notInitialized];
-        
+        [self initializeWithParameters:(id<MAAdapterInitializationParameters>)parameters completionHandler:^(MAAdapterInitializationStatus initializationStatus, NSString * _Nullable errorMessage) {}];
         return;
     }
     
@@ -267,7 +267,7 @@ static MAAdapterInitializationStatus ALVungleIntializationStatus = NSIntegerMin;
     {
         [self log: @"Vungle SDK not successfully initialized: failing app open ad load..."];
         [delegate didFailToLoadAppOpenAdWithError: MAAdapterError.notInitialized];
-        
+        [self initializeWithParameters:(id<MAAdapterInitializationParameters>)parameters completionHandler:^(MAAdapterInitializationStatus initializationStatus, NSString * _Nullable errorMessage) {}];
         return;
     }
     
@@ -321,7 +321,7 @@ static MAAdapterInitializationStatus ALVungleIntializationStatus = NSIntegerMin;
     {
         [self log: @"Vungle SDK not successfully initialized: failing rewarded ad load..."];
         [delegate didFailToLoadRewardedAdWithError: MAAdapterError.notInitialized];
-        
+        [self initializeWithParameters:(id<MAAdapterInitializationParameters>)parameters completionHandler:^(MAAdapterInitializationStatus initializationStatus, NSString * _Nullable errorMessage) {}];
         return;
     }
     
@@ -386,7 +386,7 @@ static MAAdapterInitializationStatus ALVungleIntializationStatus = NSIntegerMin;
     {
         [self log: @"Vungle SDK not successfully initialized: failing %@ ad load...", adFormatLabel];
         [delegate didFailToLoadAdViewAdWithError: MAAdapterError.notInitialized];
-        
+        [self initializeWithParameters:(id<MAAdapterInitializationParameters>)parameters completionHandler:^(MAAdapterInitializationStatus initializationStatus, NSString * _Nullable errorMessage) {}];
         return;
     }
     
@@ -431,7 +431,7 @@ static MAAdapterInitializationStatus ALVungleIntializationStatus = NSIntegerMin;
     {
         [self log: @"Vungle SDK not successfully initialized: failing native ad load..."];
         [delegate didFailToLoadNativeAdWithError: MAAdapterError.notInitialized];
-        
+        [self initializeWithParameters:(id<MAAdapterInitializationParameters>)parameters completionHandler:^(MAAdapterInitializationStatus initializationStatus, NSString * _Nullable errorMessage) {}];
         return;
     }
     

--- a/Vungle/VungleAdapter/ALVungleMediationAdapter.m
+++ b/Vungle/VungleAdapter/ALVungleMediationAdapter.m
@@ -174,7 +174,7 @@ static NSMutableSet<void (^)(MAAdapterInitializationStatus, NSString *_Nullable)
                 }
             }
         }];
-    } 
+    }
     else
     {
         completionHandler(ALVungleIntializationStatus, nil);

--- a/Vungle/VungleAdapter/ALVungleMediationAdapter.m
+++ b/Vungle/VungleAdapter/ALVungleMediationAdapter.m
@@ -117,7 +117,7 @@ static MAAdapterInitializationStatus ALVungleIntializationStatus = NSIntegerMin;
     {
         ALVungleIntializationStatus = MAAdapterInitializationStatusInitializing;
         
-        NSString *appID = [parameters.serverParameters al_stringForKey: @"app_id"];
+        NSString *appID = [parameters.serverParameters al_stringForKey: @"app_id"] ? :@"";
         [self log: @"Initializing Vungle SDK with app id: %@...", appID];
         
         [VungleAds setIntegrationName: @"max" version: ADAPTER_VERSION];
@@ -207,19 +207,27 @@ static MAAdapterInitializationStatus ALVungleIntializationStatus = NSIntegerMin;
     
     if ( ![VungleAds isInitialized] )
     {
-        [self log: @"Vungle SDK not successfully initialized: failing interstitial ad load..."];
-        [delegate didFailToLoadInterstitialAdWithError: MAAdapterError.notInitialized];
-        [self initializeWithParameters:(id<MAAdapterInitializationParameters>)parameters completionHandler:^(MAAdapterInitializationStatus initializationStatus, NSString * _Nullable errorMessage) {}];
-        return;
+        [self initializeWithParameters:(id<MAAdapterInitializationParameters>)parameters completionHandler:^(MAAdapterInitializationStatus initializationStatus, NSString * _Nullable errorMessage) {
+            if ( initializationStatus == MAAdapterInitializationStatusInitializedFailure ) {
+                [self log: @"Vungle SDK not successfully initialized: failing interstitial ad load..."];
+                [delegate didFailToLoadInterstitialAdWithError: MAAdapterError.notInitialized];
+            } else if ( initializationStatus == MAAdapterInitializationStatusInitializedSuccess ) {
+                self.interstitialAd = [[VungleInterstitial alloc] initWithPlacementId: placementIdentifier];
+                self.interstitialAdDelegate = [[ALVungleMediationAdapterInterstitialAdDelegate alloc] initWithParentAdapter: self andNotify: delegate];
+                self.interstitialAd.delegate = self.interstitialAdDelegate;
+                
+                [self.interstitialAd load: bidResponse];
+            }
+        }];
+    } else {
+        [self updateUserPrivacySettingsForParameters: parameters];
+        
+        self.interstitialAd = [[VungleInterstitial alloc] initWithPlacementId: placementIdentifier];
+        self.interstitialAdDelegate = [[ALVungleMediationAdapterInterstitialAdDelegate alloc] initWithParentAdapter: self andNotify: delegate];
+        self.interstitialAd.delegate = self.interstitialAdDelegate;
+        
+        [self.interstitialAd load: bidResponse];
     }
-    
-    [self updateUserPrivacySettingsForParameters: parameters];
-    
-    self.interstitialAd = [[VungleInterstitial alloc] initWithPlacementId: placementIdentifier];
-    self.interstitialAdDelegate = [[ALVungleMediationAdapterInterstitialAdDelegate alloc] initWithParentAdapter: self andNotify: delegate];
-    self.interstitialAd.delegate = self.interstitialAdDelegate;
-    
-    [self.interstitialAd load: bidResponse];
 }
 
 - (void)showInterstitialAdForParameters:(id<MAAdapterResponseParameters>)parameters andNotify:(id<MAInterstitialAdapterDelegate>)delegate
@@ -265,19 +273,27 @@ static MAAdapterInitializationStatus ALVungleIntializationStatus = NSIntegerMin;
     
     if ( ![VungleAds isInitialized] )
     {
-        [self log: @"Vungle SDK not successfully initialized: failing app open ad load..."];
-        [delegate didFailToLoadAppOpenAdWithError: MAAdapterError.notInitialized];
-        [self initializeWithParameters:(id<MAAdapterInitializationParameters>)parameters completionHandler:^(MAAdapterInitializationStatus initializationStatus, NSString * _Nullable errorMessage) {}];
-        return;
+        [self initializeWithParameters:(id<MAAdapterInitializationParameters>)parameters completionHandler:^(MAAdapterInitializationStatus initializationStatus, NSString * _Nullable errorMessage) {
+            if ( initializationStatus == MAAdapterInitializationStatusInitializedFailure ) {
+                [self log: @"Vungle SDK not successfully initialized: failing app open ad load..."];
+                [delegate didFailToLoadAppOpenAdWithError: MAAdapterError.notInitialized];
+            } else if ( initializationStatus == MAAdapterInitializationStatusInitializedSuccess ) {
+                self.appOpenAdDelegate = [[ALVungleMediationAdapterAppOpenAdDelegate alloc] initWithParentAdapter: self andNotify: delegate];
+                self.appOpenAd = [[VungleInterstitial alloc] initWithPlacementId: placementIdentifier];
+                self.appOpenAd.delegate = self.appOpenAdDelegate;
+                
+                [self.appOpenAd load: bidResponse];
+            }
+        }];
+    } else {
+        [self updateUserPrivacySettingsForParameters: parameters];
+        
+        self.appOpenAdDelegate = [[ALVungleMediationAdapterAppOpenAdDelegate alloc] initWithParentAdapter: self andNotify: delegate];
+        self.appOpenAd = [[VungleInterstitial alloc] initWithPlacementId: placementIdentifier];
+        self.appOpenAd.delegate = self.appOpenAdDelegate;
+        
+        [self.appOpenAd load: bidResponse];
     }
-    
-    [self updateUserPrivacySettingsForParameters: parameters];
-    
-    self.appOpenAdDelegate = [[ALVungleMediationAdapterAppOpenAdDelegate alloc] initWithParentAdapter: self andNotify: delegate];
-    self.appOpenAd = [[VungleInterstitial alloc] initWithPlacementId: placementIdentifier];
-    self.appOpenAd.delegate = self.appOpenAdDelegate;
-    
-    [self.appOpenAd load: bidResponse];
 }
 
 - (void)showAppOpenAdForParameters:(id<MAAdapterResponseParameters>)parameters andNotify:(id<MAAppOpenAdapterDelegate>)delegate
@@ -319,19 +335,27 @@ static MAAdapterInitializationStatus ALVungleIntializationStatus = NSIntegerMin;
     
     if ( ![VungleAds isInitialized] )
     {
-        [self log: @"Vungle SDK not successfully initialized: failing rewarded ad load..."];
-        [delegate didFailToLoadRewardedAdWithError: MAAdapterError.notInitialized];
-        [self initializeWithParameters:(id<MAAdapterInitializationParameters>)parameters completionHandler:^(MAAdapterInitializationStatus initializationStatus, NSString * _Nullable errorMessage) {}];
-        return;
+        [self initializeWithParameters:(id<MAAdapterInitializationParameters>)parameters completionHandler:^(MAAdapterInitializationStatus initializationStatus, NSString * _Nullable errorMessage) {
+            if ( initializationStatus == MAAdapterInitializationStatusInitializedFailure ) {
+                [self log: @"Vungle SDK not successfully initialized: failing rewarded ad load..."];
+                [delegate didFailToLoadRewardedAdWithError: MAAdapterError.notInitialized];
+            } else if ( initializationStatus == MAAdapterInitializationStatusInitializedSuccess ) {
+                self.rewardedAd = [[VungleRewarded alloc] initWithPlacementId: placementIdentifier];
+                self.rewardedAdDelegate = [[ALVungleMediationAdapterRewardedAdDelegate alloc] initWithParentAdapter: self andNotify: delegate];
+                self.rewardedAd.delegate = self.rewardedAdDelegate;
+                
+                [self.rewardedAd load: bidResponse];
+            }
+        }];
+    } else {
+        [self updateUserPrivacySettingsForParameters: parameters];
+        
+        self.rewardedAd = [[VungleRewarded alloc] initWithPlacementId: placementIdentifier];
+        self.rewardedAdDelegate = [[ALVungleMediationAdapterRewardedAdDelegate alloc] initWithParentAdapter: self andNotify: delegate];
+        self.rewardedAd.delegate = self.rewardedAdDelegate;
+        
+        [self.rewardedAd load: bidResponse];
     }
-    
-    [self updateUserPrivacySettingsForParameters: parameters];
-    
-    self.rewardedAd = [[VungleRewarded alloc] initWithPlacementId: placementIdentifier];
-    self.rewardedAdDelegate = [[ALVungleMediationAdapterRewardedAdDelegate alloc] initWithParentAdapter: self andNotify: delegate];
-    self.rewardedAd.delegate = self.rewardedAdDelegate;
-    
-    [self.rewardedAd load: bidResponse];
 }
 
 - (void)showRewardedAdForParameters:(id<MAAdapterResponseParameters>)parameters andNotify:(id<MARewardedAdapterDelegate>)delegate
@@ -384,36 +408,62 @@ static MAAdapterInitializationStatus ALVungleIntializationStatus = NSIntegerMin;
     
     if ( ![VungleAds isInitialized] )
     {
-        [self log: @"Vungle SDK not successfully initialized: failing %@ ad load...", adFormatLabel];
-        [delegate didFailToLoadAdViewAdWithError: MAAdapterError.notInitialized];
-        [self initializeWithParameters:(id<MAAdapterInitializationParameters>)parameters completionHandler:^(MAAdapterInitializationStatus initializationStatus, NSString * _Nullable errorMessage) {}];
-        return;
-    }
-    
-    [self updateUserPrivacySettingsForParameters: parameters];
-    
-    if ( isNative )
-    {
-        self.nativeAdViewDelegate = [[ALVungleMediationAdapterNativeAdViewDelegate alloc] initWithParentAdapter: self
+        [self initializeWithParameters:(id<MAAdapterInitializationParameters>)parameters completionHandler:^(MAAdapterInitializationStatus initializationStatus, NSString * _Nullable errorMessage) {
+            if ( initializationStatus == MAAdapterInitializationStatusInitializedFailure ) {
+                [self log: @"Vungle SDK not successfully initialized: failing %@ ad load...", adFormatLabel];
+                [delegate didFailToLoadAdViewAdWithError: MAAdapterError.notInitialized];
+            } else if ( initializationStatus == MAAdapterInitializationStatusInitializedSuccess ) {
+                if ( isNative )
+                {
+                    self.nativeAdViewDelegate = [[ALVungleMediationAdapterNativeAdViewDelegate alloc] initWithParentAdapter: self
+                                                                                                                     format: adFormat
+                                                                                                                 parameters: parameters
+                                                                                                                  andNotify: delegate];
+                    [self loadVungleNativeAdForParameters: parameters andNotify: self.nativeAdViewDelegate];
+                }
+                else
+                {
+                    BannerSize adSize = [self adSizeFromAdFormat: adFormat];
+                    
+                    self.adView = [[VungleBanner alloc] initWithPlacementId: placementIdentifier size: adSize];
+                    self.adViewDelegate = [[ALVungleMediationAdapterAdViewDelegate alloc] initWithParentAdapter: self
                                                                                                          format: adFormat
                                                                                                      parameters: parameters
                                                                                                       andNotify: delegate];
-        [self loadVungleNativeAdForParameters: parameters andNotify: self.nativeAdViewDelegate];
-    }
-    else
-    {
-        BannerSize adSize = [self adSizeFromAdFormat: adFormat];
+                    self.adView.delegate = self.adViewDelegate;
+                            
+                    self.adViewContainer = [[UIView alloc] initWithFrame: (CGRect) { CGPointZero, adFormat.size }];
+                    
+                    [self.adView load: bidResponse];
+                }
+            }
+        }];
+    } else {
+        [self updateUserPrivacySettingsForParameters: parameters];
         
-        self.adView = [[VungleBanner alloc] initWithPlacementId: placementIdentifier size: adSize];
-        self.adViewDelegate = [[ALVungleMediationAdapterAdViewDelegate alloc] initWithParentAdapter: self
-                                                                                             format: adFormat
-                                                                                         parameters: parameters
-                                                                                          andNotify: delegate];
-        self.adView.delegate = self.adViewDelegate;
-                
-        self.adViewContainer = [[UIView alloc] initWithFrame: (CGRect) { CGPointZero, adFormat.size }];
-        
-        [self.adView load: bidResponse];
+        if ( isNative )
+        {
+            self.nativeAdViewDelegate = [[ALVungleMediationAdapterNativeAdViewDelegate alloc] initWithParentAdapter: self
+                                                                                                             format: adFormat
+                                                                                                         parameters: parameters
+                                                                                                          andNotify: delegate];
+            [self loadVungleNativeAdForParameters: parameters andNotify: self.nativeAdViewDelegate];
+        }
+        else
+        {
+            BannerSize adSize = [self adSizeFromAdFormat: adFormat];
+            
+            self.adView = [[VungleBanner alloc] initWithPlacementId: placementIdentifier size: adSize];
+            self.adViewDelegate = [[ALVungleMediationAdapterAdViewDelegate alloc] initWithParentAdapter: self
+                                                                                                 format: adFormat
+                                                                                             parameters: parameters
+                                                                                              andNotify: delegate];
+            self.adView.delegate = self.adViewDelegate;
+                    
+            self.adViewContainer = [[UIView alloc] initWithFrame: (CGRect) { CGPointZero, adFormat.size }];
+            
+            [self.adView load: bidResponse];
+        }
     }
 }
 
@@ -429,18 +479,25 @@ static MAAdapterInitializationStatus ALVungleIntializationStatus = NSIntegerMin;
     
     if ( ![VungleAds isInitialized] )
     {
-        [self log: @"Vungle SDK not successfully initialized: failing native ad load..."];
-        [delegate didFailToLoadNativeAdWithError: MAAdapterError.notInitialized];
-        [self initializeWithParameters:(id<MAAdapterInitializationParameters>)parameters completionHandler:^(MAAdapterInitializationStatus initializationStatus, NSString * _Nullable errorMessage) {}];
-        return;
+        [self initializeWithParameters:(id<MAAdapterInitializationParameters>)parameters completionHandler:^(MAAdapterInitializationStatus initializationStatus, NSString * _Nullable errorMessage) {
+            if (initializationStatus == MAAdapterInitializationStatusInitializedFailure) {
+                [self log: @"Vungle SDK not successfully initialized: failing native ad load..."];
+                [delegate didFailToLoadNativeAdWithError: MAAdapterError.notInitialized];
+            } else if (initializationStatus == MAAdapterInitializationStatusInitializedSuccess) {
+                self.nativeAdDelegate = [[ALVungleMediationAdapterNativeAdDelegate alloc] initWithParentAdapter: self
+                                                                                                     parameters: parameters
+                                                                                                      andNotify: delegate];
+                [self loadVungleNativeAdForParameters: parameters andNotify: self.nativeAdDelegate];
+            }
+        }];
+    } else {
+        [self updateUserPrivacySettingsForParameters: parameters];
+        
+        self.nativeAdDelegate = [[ALVungleMediationAdapterNativeAdDelegate alloc] initWithParentAdapter: self
+                                                                                             parameters: parameters
+                                                                                              andNotify: delegate];
+        [self loadVungleNativeAdForParameters: parameters andNotify: self.nativeAdDelegate];
     }
-    
-    [self updateUserPrivacySettingsForParameters: parameters];
-    
-    self.nativeAdDelegate = [[ALVungleMediationAdapterNativeAdDelegate alloc] initWithParentAdapter: self
-                                                                                         parameters: parameters
-                                                                                          andNotify: delegate];
-    [self loadVungleNativeAdForParameters: parameters andNotify: self.nativeAdDelegate];
 }
 
 #pragma mark - Shared Methods

--- a/Vungle/VungleAdapter/ALVungleMediationAdapter.m
+++ b/Vungle/VungleAdapter/ALVungleMediationAdapter.m
@@ -129,6 +129,9 @@ static NSMutableSet<void (^)(MAAdapterInitializationStatus, NSString *_Nullable)
     {
         @synchronized(completionHandlers)
         {
+            if (completionHandlers == nil) {
+                completionHandlers = [NSMutableSet set];
+            }
             [completionHandlers addObject: completionHandler];
         }
         

--- a/Vungle/VungleAdapter/ALVungleMediationAdapter.m
+++ b/Vungle/VungleAdapter/ALVungleMediationAdapter.m
@@ -246,7 +246,7 @@ static NSMutableSet<void (^)(MAAdapterInitializationStatus, NSString *_Nullable)
     [self initVungleSDK:parameters completionHandler:^(MAAdapterInitializationStatus initializationStatus, NSString * _Nullable errorMessage) {
         if ( initializationStatus == MAAdapterInitializationStatusInitializedFailure ) 
         {
-            [self log: @"Vungle SDK not successfully initialized: failing interstitial ad load..."];
+            [self log: @"Vungle SDK not successfully initialized: failing interstitial ad load with error %@", errorMessage];
             [delegate didFailToLoadInterstitialAdWithError: MAAdapterError.notInitialized];
         } 
         else
@@ -306,7 +306,7 @@ static NSMutableSet<void (^)(MAAdapterInitializationStatus, NSString *_Nullable)
     [self initVungleSDK:parameters completionHandler:^(MAAdapterInitializationStatus initializationStatus, NSString * _Nullable errorMessage) {
         if ( initializationStatus == MAAdapterInitializationStatusInitializedFailure ) 
         {
-            [self log: @"Vungle SDK not successfully initialized: failing app open ad load..."];
+            [self log: @"Vungle SDK not successfully initialized: failing app open ad load with error %@", errorMessage];
             [delegate didFailToLoadAppOpenAdWithError: MAAdapterError.notInitialized];
         } 
         else
@@ -362,7 +362,7 @@ static NSMutableSet<void (^)(MAAdapterInitializationStatus, NSString *_Nullable)
     [self initVungleSDK:parameters completionHandler:^(MAAdapterInitializationStatus initializationStatus, NSString * _Nullable errorMessage) {
         if ( initializationStatus == MAAdapterInitializationStatusInitializedFailure ) 
         {
-            [self log: @"Vungle SDK not successfully initialized: failing rewarded ad load..."];
+            [self log: @"Vungle SDK not successfully initialized: failing rewarded ad load with error %@", errorMessage];
             [delegate didFailToLoadRewardedAdWithError: MAAdapterError.notInitialized];
         } 
         else
@@ -429,7 +429,7 @@ static NSMutableSet<void (^)(MAAdapterInitializationStatus, NSString *_Nullable)
     [self initVungleSDK:parameters completionHandler:^(MAAdapterInitializationStatus initializationStatus, NSString * _Nullable errorMessage) {
         if ( initializationStatus == MAAdapterInitializationStatusInitializedFailure ) 
         {
-            [self log: @"Vungle SDK not successfully initialized: failing %@ ad load...", adFormatLabel];
+            [self log: @"Vungle SDK not successfully initialized: failing %@ ad load with error %@", adFormatLabel, errorMessage];
             [delegate didFailToLoadAdViewAdWithError: MAAdapterError.notInitialized];
         } 
         else
@@ -476,7 +476,7 @@ static NSMutableSet<void (^)(MAAdapterInitializationStatus, NSString *_Nullable)
     [self initVungleSDK:parameters completionHandler:^(MAAdapterInitializationStatus initializationStatus, NSString * _Nullable errorMessage) {
         if ( initializationStatus == MAAdapterInitializationStatusInitializedFailure ) 
         {
-            [self log: @"Vungle SDK not successfully initialized: failing native ad load..."];
+            [self log: @"Vungle SDK not successfully initialized: failing native ad load with error %@", errorMessage];
             [delegate didFailToLoadNativeAdWithError: MAAdapterError.notInitialized];
         } 
         else

--- a/Vungle/VungleAdapter/ALVungleMediationAdapter.m
+++ b/Vungle/VungleAdapter/ALVungleMediationAdapter.m
@@ -115,6 +115,16 @@ static MAAdapterInitializationStatus ALVungleIntializationStatus = NSIntegerMin;
     
     if ( [ALVungleInitialized compareAndSet: NO update: YES] )
     {
+        [self initVungleSDK:parameters completionHandler:completionHandler];
+    }
+    else
+    {
+        completionHandler(ALVungleIntializationStatus, nil);
+    }
+}
+
+- (void)initVungleSDK:(id<MAAdapterInitializationParameters>)parameters completionHandler:(void (^)(MAAdapterInitializationStatus, NSString *_Nullable))completionHandler {
+    if ( ![VungleAds isInitialized] ) {
         ALVungleIntializationStatus = MAAdapterInitializationStatusInitializing;
         
         NSString *appID = [parameters.serverParameters al_stringForKey: @"app_id"] ? :@"";
@@ -139,7 +149,7 @@ static MAAdapterInitializationStatus ALVungleIntializationStatus = NSIntegerMin;
                 completionHandler(ALVungleIntializationStatus, nil);
             }
         }];
-    }
+    } 
     else
     {
         completionHandler(ALVungleIntializationStatus, nil);
@@ -205,29 +215,23 @@ static MAAdapterInitializationStatus ALVungleIntializationStatus = NSIntegerMin;
     NSString *placementIdentifier = parameters.thirdPartyAdPlacementIdentifier;
     [self log: @"Loading %@interstitial ad for placement: %@...", ( isBiddingAd ? @"bidding " : @"" ), placementIdentifier];
     
-    if ( ![VungleAds isInitialized] )
-    {
-        [self initializeWithParameters:(id<MAAdapterInitializationParameters>)parameters completionHandler:^(MAAdapterInitializationStatus initializationStatus, NSString * _Nullable errorMessage) {
-            if ( initializationStatus == MAAdapterInitializationStatusInitializedFailure ) {
-                [self log: @"Vungle SDK not successfully initialized: failing interstitial ad load..."];
-                [delegate didFailToLoadInterstitialAdWithError: MAAdapterError.notInitialized];
-            } else if ( initializationStatus == MAAdapterInitializationStatusInitializedSuccess ) {
-                self.interstitialAd = [[VungleInterstitial alloc] initWithPlacementId: placementIdentifier];
-                self.interstitialAdDelegate = [[ALVungleMediationAdapterInterstitialAdDelegate alloc] initWithParentAdapter: self andNotify: delegate];
-                self.interstitialAd.delegate = self.interstitialAdDelegate;
-                
-                [self.interstitialAd load: bidResponse];
-            }
-        }];
-    } else {
-        [self updateUserPrivacySettingsForParameters: parameters];
-        
-        self.interstitialAd = [[VungleInterstitial alloc] initWithPlacementId: placementIdentifier];
-        self.interstitialAdDelegate = [[ALVungleMediationAdapterInterstitialAdDelegate alloc] initWithParentAdapter: self andNotify: delegate];
-        self.interstitialAd.delegate = self.interstitialAdDelegate;
-        
-        [self.interstitialAd load: bidResponse];
-    }
+    [self initVungleSDK:(id<MAAdapterInitializationParameters>)parameters completionHandler:^(MAAdapterInitializationStatus initializationStatus, NSString * _Nullable errorMessage) {
+        if ( initializationStatus == MAAdapterInitializationStatusInitializedFailure ) 
+        {
+            [self log: @"Vungle SDK not successfully initialized: failing interstitial ad load..."];
+            [delegate didFailToLoadInterstitialAdWithError: MAAdapterError.notInitialized];
+        } 
+        else
+        {
+            [self updateUserPrivacySettingsForParameters: parameters];
+            
+            self.interstitialAd = [[VungleInterstitial alloc] initWithPlacementId: placementIdentifier];
+            self.interstitialAdDelegate = [[ALVungleMediationAdapterInterstitialAdDelegate alloc] initWithParentAdapter: self andNotify: delegate];
+            self.interstitialAd.delegate = self.interstitialAdDelegate;
+            
+            [self.interstitialAd load: bidResponse];
+        }
+    }];
 }
 
 - (void)showInterstitialAdForParameters:(id<MAAdapterResponseParameters>)parameters andNotify:(id<MAInterstitialAdapterDelegate>)delegate
@@ -271,29 +275,23 @@ static MAAdapterInitializationStatus ALVungleIntializationStatus = NSIntegerMin;
     NSString *placementIdentifier = parameters.thirdPartyAdPlacementIdentifier;
     [self log: @"Loading %@app open ad for placement: %@...", ( isBiddingAd ? @"bidding " : @"" ), placementIdentifier];
     
-    if ( ![VungleAds isInitialized] )
-    {
-        [self initializeWithParameters:(id<MAAdapterInitializationParameters>)parameters completionHandler:^(MAAdapterInitializationStatus initializationStatus, NSString * _Nullable errorMessage) {
-            if ( initializationStatus == MAAdapterInitializationStatusInitializedFailure ) {
-                [self log: @"Vungle SDK not successfully initialized: failing app open ad load..."];
-                [delegate didFailToLoadAppOpenAdWithError: MAAdapterError.notInitialized];
-            } else if ( initializationStatus == MAAdapterInitializationStatusInitializedSuccess ) {
-                self.appOpenAdDelegate = [[ALVungleMediationAdapterAppOpenAdDelegate alloc] initWithParentAdapter: self andNotify: delegate];
-                self.appOpenAd = [[VungleInterstitial alloc] initWithPlacementId: placementIdentifier];
-                self.appOpenAd.delegate = self.appOpenAdDelegate;
-                
-                [self.appOpenAd load: bidResponse];
-            }
-        }];
-    } else {
-        [self updateUserPrivacySettingsForParameters: parameters];
-        
-        self.appOpenAdDelegate = [[ALVungleMediationAdapterAppOpenAdDelegate alloc] initWithParentAdapter: self andNotify: delegate];
-        self.appOpenAd = [[VungleInterstitial alloc] initWithPlacementId: placementIdentifier];
-        self.appOpenAd.delegate = self.appOpenAdDelegate;
-        
-        [self.appOpenAd load: bidResponse];
-    }
+    [self initVungleSDK:(id<MAAdapterInitializationParameters>)parameters completionHandler:^(MAAdapterInitializationStatus initializationStatus, NSString * _Nullable errorMessage) {
+        if ( initializationStatus == MAAdapterInitializationStatusInitializedFailure ) 
+        {
+            [self log: @"Vungle SDK not successfully initialized: failing app open ad load..."];
+            [delegate didFailToLoadAppOpenAdWithError: MAAdapterError.notInitialized];
+        } 
+        else
+        {
+            [self updateUserPrivacySettingsForParameters: parameters];
+            
+            self.appOpenAdDelegate = [[ALVungleMediationAdapterAppOpenAdDelegate alloc] initWithParentAdapter: self andNotify: delegate];
+            self.appOpenAd = [[VungleInterstitial alloc] initWithPlacementId: placementIdentifier];
+            self.appOpenAd.delegate = self.appOpenAdDelegate;
+            
+            [self.appOpenAd load: bidResponse];
+        }
+    }];
 }
 
 - (void)showAppOpenAdForParameters:(id<MAAdapterResponseParameters>)parameters andNotify:(id<MAAppOpenAdapterDelegate>)delegate
@@ -333,29 +331,23 @@ static MAAdapterInitializationStatus ALVungleIntializationStatus = NSIntegerMin;
     NSString *placementIdentifier = parameters.thirdPartyAdPlacementIdentifier;
     [self log: @"Loading %@rewarded ad for placement: %@...", ( isBiddingAd ? @"bidding " : @"" ), placementIdentifier];
     
-    if ( ![VungleAds isInitialized] )
-    {
-        [self initializeWithParameters:(id<MAAdapterInitializationParameters>)parameters completionHandler:^(MAAdapterInitializationStatus initializationStatus, NSString * _Nullable errorMessage) {
-            if ( initializationStatus == MAAdapterInitializationStatusInitializedFailure ) {
-                [self log: @"Vungle SDK not successfully initialized: failing rewarded ad load..."];
-                [delegate didFailToLoadRewardedAdWithError: MAAdapterError.notInitialized];
-            } else if ( initializationStatus == MAAdapterInitializationStatusInitializedSuccess ) {
-                self.rewardedAd = [[VungleRewarded alloc] initWithPlacementId: placementIdentifier];
-                self.rewardedAdDelegate = [[ALVungleMediationAdapterRewardedAdDelegate alloc] initWithParentAdapter: self andNotify: delegate];
-                self.rewardedAd.delegate = self.rewardedAdDelegate;
-                
-                [self.rewardedAd load: bidResponse];
-            }
-        }];
-    } else {
-        [self updateUserPrivacySettingsForParameters: parameters];
-        
-        self.rewardedAd = [[VungleRewarded alloc] initWithPlacementId: placementIdentifier];
-        self.rewardedAdDelegate = [[ALVungleMediationAdapterRewardedAdDelegate alloc] initWithParentAdapter: self andNotify: delegate];
-        self.rewardedAd.delegate = self.rewardedAdDelegate;
-        
-        [self.rewardedAd load: bidResponse];
-    }
+    [self initVungleSDK:(id<MAAdapterInitializationParameters>)parameters completionHandler:^(MAAdapterInitializationStatus initializationStatus, NSString * _Nullable errorMessage) {
+        if ( initializationStatus == MAAdapterInitializationStatusInitializedFailure ) 
+        {
+            [self log: @"Vungle SDK not successfully initialized: failing rewarded ad load..."];
+            [delegate didFailToLoadRewardedAdWithError: MAAdapterError.notInitialized];
+        } 
+        else
+        {
+            [self updateUserPrivacySettingsForParameters: parameters];
+            
+            self.rewardedAd = [[VungleRewarded alloc] initWithPlacementId: placementIdentifier];
+            self.rewardedAdDelegate = [[ALVungleMediationAdapterRewardedAdDelegate alloc] initWithParentAdapter: self andNotify: delegate];
+            self.rewardedAd.delegate = self.rewardedAdDelegate;
+            
+            [self.rewardedAd load: bidResponse];
+        }
+    }];
 }
 
 - (void)showRewardedAdForParameters:(id<MAAdapterResponseParameters>)parameters andNotify:(id<MARewardedAdapterDelegate>)delegate
@@ -406,65 +398,41 @@ static MAAdapterInitializationStatus ALVungleIntializationStatus = NSIntegerMin;
     
     [self log: @"Loading %@%@%@ ad for placement: %@...", ( isBiddingAd ? @"bidding " : @"" ), ( isNative ? @"native " : @"" ), adFormatLabel, placementIdentifier];
     
-    if ( ![VungleAds isInitialized] )
-    {
-        [self initializeWithParameters:(id<MAAdapterInitializationParameters>)parameters completionHandler:^(MAAdapterInitializationStatus initializationStatus, NSString * _Nullable errorMessage) {
-            if ( initializationStatus == MAAdapterInitializationStatusInitializedFailure ) {
-                [self log: @"Vungle SDK not successfully initialized: failing %@ ad load...", adFormatLabel];
-                [delegate didFailToLoadAdViewAdWithError: MAAdapterError.notInitialized];
-            } else if ( initializationStatus == MAAdapterInitializationStatusInitializedSuccess ) {
-                if ( isNative )
-                {
-                    self.nativeAdViewDelegate = [[ALVungleMediationAdapterNativeAdViewDelegate alloc] initWithParentAdapter: self
-                                                                                                                     format: adFormat
-                                                                                                                 parameters: parameters
-                                                                                                                  andNotify: delegate];
-                    [self loadVungleNativeAdForParameters: parameters andNotify: self.nativeAdViewDelegate];
-                }
-                else
-                {
-                    BannerSize adSize = [self adSizeFromAdFormat: adFormat];
-                    
-                    self.adView = [[VungleBanner alloc] initWithPlacementId: placementIdentifier size: adSize];
-                    self.adViewDelegate = [[ALVungleMediationAdapterAdViewDelegate alloc] initWithParentAdapter: self
-                                                                                                         format: adFormat
-                                                                                                     parameters: parameters
-                                                                                                      andNotify: delegate];
-                    self.adView.delegate = self.adViewDelegate;
-                            
-                    self.adViewContainer = [[UIView alloc] initWithFrame: (CGRect) { CGPointZero, adFormat.size }];
-                    
-                    [self.adView load: bidResponse];
-                }
-            }
-        }];
-    } else {
-        [self updateUserPrivacySettingsForParameters: parameters];
-        
-        if ( isNative )
+    [self initVungleSDK:(id<MAAdapterInitializationParameters>)parameters completionHandler:^(MAAdapterInitializationStatus initializationStatus, NSString * _Nullable errorMessage) {
+        if ( initializationStatus == MAAdapterInitializationStatusInitializedFailure ) 
         {
-            self.nativeAdViewDelegate = [[ALVungleMediationAdapterNativeAdViewDelegate alloc] initWithParentAdapter: self
-                                                                                                             format: adFormat
-                                                                                                         parameters: parameters
-                                                                                                          andNotify: delegate];
-            [self loadVungleNativeAdForParameters: parameters andNotify: self.nativeAdViewDelegate];
-        }
+            [self log: @"Vungle SDK not successfully initialized: failing %@ ad load...", adFormatLabel];
+            [delegate didFailToLoadAdViewAdWithError: MAAdapterError.notInitialized];
+        } 
         else
         {
-            BannerSize adSize = [self adSizeFromAdFormat: adFormat];
+            [self updateUserPrivacySettingsForParameters: parameters];
             
-            self.adView = [[VungleBanner alloc] initWithPlacementId: placementIdentifier size: adSize];
-            self.adViewDelegate = [[ALVungleMediationAdapterAdViewDelegate alloc] initWithParentAdapter: self
-                                                                                                 format: adFormat
-                                                                                             parameters: parameters
-                                                                                              andNotify: delegate];
-            self.adView.delegate = self.adViewDelegate;
-                    
-            self.adViewContainer = [[UIView alloc] initWithFrame: (CGRect) { CGPointZero, adFormat.size }];
-            
-            [self.adView load: bidResponse];
+            if ( isNative )
+            {
+                self.nativeAdViewDelegate = [[ALVungleMediationAdapterNativeAdViewDelegate alloc] initWithParentAdapter: self
+                                                                                                                 format: adFormat
+                                                                                                             parameters: parameters
+                                                                                                              andNotify: delegate];
+                [self loadVungleNativeAdForParameters: parameters andNotify: self.nativeAdViewDelegate];
+            }
+            else
+            {
+                BannerSize adSize = [self adSizeFromAdFormat: adFormat];
+                
+                self.adView = [[VungleBanner alloc] initWithPlacementId: placementIdentifier size: adSize];
+                self.adViewDelegate = [[ALVungleMediationAdapterAdViewDelegate alloc] initWithParentAdapter: self
+                                                                                                     format: adFormat
+                                                                                                 parameters: parameters
+                                                                                                  andNotify: delegate];
+                self.adView.delegate = self.adViewDelegate;
+                        
+                self.adViewContainer = [[UIView alloc] initWithFrame: (CGRect) { CGPointZero, adFormat.size }];
+                
+                [self.adView load: bidResponse];
+            }
         }
-    }
+    }];
 }
 
 #pragma mark - MANativeAdAdapter Methods
@@ -477,27 +445,22 @@ static MAAdapterInitializationStatus ALVungleIntializationStatus = NSIntegerMin;
     
     [self log: @"Loading %@native ad for placement: %@...", ( isBiddingAd ? @"bidding " : @"" ), placementIdentifier];
     
-    if ( ![VungleAds isInitialized] )
-    {
-        [self initializeWithParameters:(id<MAAdapterInitializationParameters>)parameters completionHandler:^(MAAdapterInitializationStatus initializationStatus, NSString * _Nullable errorMessage) {
-            if (initializationStatus == MAAdapterInitializationStatusInitializedFailure) {
-                [self log: @"Vungle SDK not successfully initialized: failing native ad load..."];
-                [delegate didFailToLoadNativeAdWithError: MAAdapterError.notInitialized];
-            } else if (initializationStatus == MAAdapterInitializationStatusInitializedSuccess) {
-                self.nativeAdDelegate = [[ALVungleMediationAdapterNativeAdDelegate alloc] initWithParentAdapter: self
-                                                                                                     parameters: parameters
-                                                                                                      andNotify: delegate];
-                [self loadVungleNativeAdForParameters: parameters andNotify: self.nativeAdDelegate];
-            }
-        }];
-    } else {
-        [self updateUserPrivacySettingsForParameters: parameters];
-        
-        self.nativeAdDelegate = [[ALVungleMediationAdapterNativeAdDelegate alloc] initWithParentAdapter: self
-                                                                                             parameters: parameters
-                                                                                              andNotify: delegate];
-        [self loadVungleNativeAdForParameters: parameters andNotify: self.nativeAdDelegate];
-    }
+    [self initVungleSDK:(id<MAAdapterInitializationParameters>)parameters completionHandler:^(MAAdapterInitializationStatus initializationStatus, NSString * _Nullable errorMessage) {
+        if ( initializationStatus == MAAdapterInitializationStatusInitializedFailure ) 
+        {
+            [self log: @"Vungle SDK not successfully initialized: failing native ad load..."];
+            [delegate didFailToLoadNativeAdWithError: MAAdapterError.notInitialized];
+        } 
+        else
+        {
+            [self updateUserPrivacySettingsForParameters: parameters];
+            
+            self.nativeAdDelegate = [[ALVungleMediationAdapterNativeAdDelegate alloc] initWithParentAdapter: self
+                                                                                                 parameters: parameters
+                                                                                                  andNotify: delegate];
+            [self loadVungleNativeAdForParameters: parameters andNotify: self.nativeAdDelegate];
+        }
+    }];
 }
 
 #pragma mark - Shared Methods

--- a/Vungle/VungleAdapter/ALVungleMediationAdapter.m
+++ b/Vungle/VungleAdapter/ALVungleMediationAdapter.m
@@ -563,64 +563,64 @@ static MAAdapterInitializationStatus ALVungleIntializationStatus = NSIntegerMin;
 {
     if ( !vungleError ) return MAAdapterError.unspecified;
     
-    int vungleErrorCode = (int) vungleError.code;
+    VungleError vungleErrorCode = vungleError.code;
     MAAdapterError *adapterError = MAAdapterError.unspecified;
     
     switch ( vungleErrorCode )
     {
-        case 6: // SDK Not Initialized
+        case VungleErrorSdkNotInitialized:
             adapterError = MAAdapterError.notInitialized;
             break;
-        case 2: // Invalid AppID
-        case 201: // Invalid PlacementID
-        case 207: // Invalid Placement Type
-        case 222: // Invalid Placement load type
-        case 500: // BannerView: Invalid Size
-        case 30001: // Ad Publisher Mismatch
+        case VungleErrorInvalidAppID:
+        case VungleErrorInvalidPlacementID:
+        case VungleErrorPlacementAdTypeMismatch:
+        case VungleErrorInvalidWaterfallPlacementID:
+        case VungleErrorBannerViewInvalidSize:
+        case VungleErrorAdPublisherMismatch:
             adapterError = MAAdapterError.invalidConfiguration;
             break;
-        case 119: // Json Encode Error
-        case 30002: // Ad Internal Integration Error
+        case VungleErrorJsonEncodeError:
+        case VungleErrorAdInternalIntegrationError:
             adapterError = MAAdapterError.internalError;
             break;
-        case 202: // Ad already Consumed
-        case 203: // Ad is already loading
-        case 204: // Ad already loaded
-        case 205: // Ad is playing
-        case 206: // Ad already failed loading
+        case VungleErrorAdConsumed:
+        case VungleErrorAdIsLoading:
+        case VungleErrorAdAlreadyLoaded:
+        case VungleErrorAdIsPlaying:
+        case VungleErrorAdAlreadyFailed:
             adapterError = MAAdapterError.invalidLoadState;
             break;
-        case 210: // Ad Not Loaded
+        case VungleErrorAdNotLoaded:
             adapterError = adPresentError ? MAAdapterError.adNotReady : MAAdapterError.invalidLoadState;
             break;
-        case 115: // Invalid IndexURL
-        case 302: // Invalid Ifa Status
-        case 305: // Mraid Bridge Error
-        case 400: // Concurrent Playback Unsupported
+        case VungleErrorInvalidIndexURL:
+        case VungleErrorInvalidIfaStatus:
+        case VungleErrorMraidBridgeError:
+        case VungleErrorConcurrentPlaybackUnsupported:
             adapterError = MAAdapterError.adDisplayFailedError;
             break;
-        case 212: // Placement Sleep
-        case 10001: // Ad No Fill
-        case 10002: // AdLoad Too Frequently
+        case VungleErrorPlacementSleep:
+        case VungleErrorAdNoFill:
+        case VungleErrorAdLoadTooFrequently:
             adapterError = MAAdapterError.noFill;
             break;
-        case 217: // Ad response timeOut
+        case VungleErrorAdResponseTimedOut:
             adapterError = MAAdapterError.timeout;
             break;
-        case 220: // Server busy with retry after timer.
-        case 221: // Load ad during Server busy with retry after timer.
-        case 20001: // Ad Server Error
+        case VungleErrorAdResponseRetryAfter:
+        case VungleErrorAdLoadFailRetryAfter:
+        case VungleErrorAdServerError:
             adapterError = MAAdapterError.serverError;
             break;
-        case 304: // Ad Expired
-        case 307: // Ad Expired on play call.
+        case VungleErrorAdExpired:
+        case VungleErrorAdExpiredOnPlay:
             adapterError = MAAdapterError.adExpiredError;
             break;
-        case 600: // Native Asset Error
+        case VungleErrorNativeAssetError:
             adapterError = MAAdapterError.missingRequiredNativeAdAssets;
             break;
-        case 2000: // webView WebContent Process Did Terminate
-        case 2001: // webView Failed Navigation
+        case VungleErrorWebViewWebContentProcessDidTerminate:
+        case VungleErrorWebViewFailedNavigation:
             adapterError = MAAdapterError.webViewError;
             break;
     }


### PR DESCRIPTION
This commit will include the changes to update the loadAd implementation in adapter to re-init SDK if the SDK has not yet initialized. Also update the error code mapping to use constants instead of numbers.

IOS-6620
IOS-6619