### PR TITLE
[IOS-6733] Introduces support for media aspect ratio

### DIFF
--- a/Vungle/VungleAdapter/ALVungleMediationAdapter.m
+++ b/Vungle/VungleAdapter/ALVungleMediationAdapter.m
@@ -1011,6 +1011,9 @@ static MAAdapterInitializationStatus ALVungleIntializationStatus = NSIntegerMin;
     
     [self.parentAdapter log: @"Native %@ ad loaded: %@", self.adFormat, self.placementIdentifier];
     
+    // returns aspect ratio of media to be displayed. Will return 0.0 by default
+    CGFloat mediaContentAspectRatio = [nativeAd getMediaAspectRatio];
+    
     dispatchOnMainQueue(^{
         MediaView *mediaView = [[MediaView alloc] init];
         
@@ -1028,6 +1031,12 @@ static MAAdapterInitializationStatus ALVungleIntializationStatus = NSIntegerMin;
             {
                 [builder performSelector: @selector(setAdvertiser:) withObject: nativeAd.sponsoredText];
             }
+            // Introduced in 11.4.0
+            if ( [builder respondsToSelector: @selector(setMediaContentAspectRatio:)] )
+            {
+                [builder performSelector: @selector(setMediaContentAspectRatio:) withObject: @(mediaContentAspectRatio)];
+            }
+
 #pragma clang diagnostic pop
         }];
         
@@ -1125,6 +1134,9 @@ static MAAdapterInitializationStatus ALVungleIntializationStatus = NSIntegerMin;
     
     [self.parentAdapter log: @"Native ad loaded: %@", self.placementIdentifier];
     
+    // returns aspect ratio of media to be displayed. Will return 0.0 by default
+    CGFloat mediaContentAspectRatio = [nativeAd getMediaAspectRatio];
+
     dispatchOnMainQueue(^{
         MediaView *mediaView = [[MediaView alloc] init];
         
@@ -1141,6 +1153,12 @@ static MAAdapterInitializationStatus ALVungleIntializationStatus = NSIntegerMin;
             if ( [builder respondsToSelector: @selector(setAdvertiser:)] )
             {
                 [builder performSelector: @selector(setAdvertiser:) withObject: nativeAd.sponsoredText];
+            }
+            
+            // Introduced in 11.4.0
+            if ( [builder respondsToSelector: @selector(setMediaContentAspectRatio:)] )
+            {
+                [builder performSelector: @selector(setMediaContentAspectRatio:) withObject: @(mediaContentAspectRatio)];
             }
 #pragma clang diagnostic pop
         }];


### PR DESCRIPTION
Adds support for medial content aspect ratio. This commit will retrieve the aspect ratio of the media to be presented from the native ad, and then set it as required so that publishers will have access to this data.

Verified the solution in test. When the native ad loads successfully, the aspect ratio API returns the expected CGFloat value. If there are any issues with ad loading (which should be prevented by other points of error handling) the method from Vungle will return a default value of 0.0.

IOS-6733