### PR TITLE
[IOS-6813] Introduces support for media aspect ratio

### DIFF
--- a/Vungle/VungleAdapter/ALVungleMediationAdapter.m
+++ b/Vungle/VungleAdapter/ALVungleMediationAdapter.m
@@ -1011,6 +1011,9 @@ static MAAdapterInitializationStatus ALVungleIntializationStatus = NSIntegerMin;
     
     [self.parentAdapter log: @"Native %@ ad loaded: %@", self.adFormat, self.placementIdentifier];
     
+    // returns aspect ratio of media to be presented. Returns 0.0 by default
+    CGFloat mediaContentAspectRatio = [nativeAd getMediaAspectRatio];
+    
     dispatchOnMainQueue(^{
         MediaView *mediaView = [[MediaView alloc] init];
         
@@ -1027,6 +1030,12 @@ static MAAdapterInitializationStatus ALVungleIntializationStatus = NSIntegerMin;
             if ( [builder respondsToSelector: @selector(setAdvertiser:)] )
             {
                 [builder performSelector: @selector(setAdvertiser:) withObject: nativeAd.sponsoredText];
+            }
+            
+            // Introduced in 11.4.0
+            if ( [builder respondsToSelector: @selector(setMediaContentAspectRatio:)] )
+            {
+                [builder performSelector: @selector(setMediaContentAspectRatio:) withObject: @(mediaContentAspectRatio)];
             }
 #pragma clang diagnostic pop
         }];


### PR DESCRIPTION
This commit supports accessing the media aspect ratio of the native ad's media. This is provided via a new API in VungleNative as part of the 7.4.0 release.

IOS-6813