### PR TITLE
[IOS-6810] Update initialization check in Vungle adapter init

### DIFF
--- a/Vungle/VungleAdapter/ALVungleMediationAdapter.m
+++ b/Vungle/VungleAdapter/ALVungleMediationAdapter.m
@@ -113,7 +113,7 @@ static MAAdapterInitializationStatus ALVungleIntializationStatus = NSIntegerMin;
 {
     [self updateUserPrivacySettingsForParameters: parameters];
     
-    if ( [ALVungleInitialized compareAndSet: NO update: YES] )
+    if ( ![ALVungleInitialized get] && ALVungleIntializationStatus != MAAdapterInitializationStatusInitializing )
     {
         ALVungleIntializationStatus = MAAdapterInitializationStatusInitializing;
         
@@ -134,7 +134,7 @@ static MAAdapterInitializationStatus ALVungleIntializationStatus = NSIntegerMin;
             else
             {
                 [self log: @"Vungle SDK initialized"];
-                
+                [ALVungleInitialized compareAndSet: NO update: YES]
                 ALVungleIntializationStatus = MAAdapterInitializationStatusInitializedSuccess;
                 completionHandler(ALVungleIntializationStatus, nil);
             }

--- a/Vungle/VungleAdapter/ALVungleMediationAdapter.m
+++ b/Vungle/VungleAdapter/ALVungleMediationAdapter.m
@@ -134,7 +134,7 @@ static MAAdapterInitializationStatus ALVungleIntializationStatus = NSIntegerMin;
             else
             {
                 [self log: @"Vungle SDK initialized"];
-                [ALVungleInitialized compareAndSet: NO update: YES]
+                [ALVungleInitialized compareAndSet: NO update: YES];
                 ALVungleIntializationStatus = MAAdapterInitializationStatusInitializedSuccess;
                 completionHandler(ALVungleIntializationStatus, nil);
             }


### PR DESCRIPTION
Fixed initialization check in VungleAds adapter to allow retries on SDK
init failures, improving reliability of ad load and playback.

IOS-6810