### PR TITLE
[IOS-6810] Revert init update, update load and callback methods

### DIFF
--- a/AmazonAdMarketplace/AmazonAdMarketplaceAdapter/ALAmazonAdMarketplaceMediationAdapter.m
+++ b/AmazonAdMarketplace/AmazonAdMarketplaceAdapter/ALAmazonAdMarketplaceMediationAdapter.m
@@ -9,7 +9,7 @@
 #import "ALAmazonAdMarketplaceMediationAdapter.h"
 #import <DTBiOSSDK/DTBiOSSDK.h>
 
-#define ADAPTER_VERSION @"4.9.2.0"
+#define ADAPTER_VERSION @"4.9.3.0"
 
 /**
  * Container object for holding mediation hints dict generated from Amazon's SDK and the timestamp it was geenrated at.

--- a/AmazonAdMarketplace/AppLovinMediationAmazonAdMarketplaceAdapter.podspec
+++ b/AmazonAdMarketplace/AppLovinMediationAmazonAdMarketplaceAdapter.podspec
@@ -2,7 +2,7 @@ Pod::Spec.new do |s|
 
 s.authors = 'AppLovin Corporation'
 s.name = 'AppLovinMediationAmazonAdMarketplaceAdapter'
-s.version = '4.9.2.0'
+s.version = '4.9.3.0'
 s.platform = :ios, '12.0'
 s.summary = 'Amazon Publisher Services adapter used for mediation with the AppLovin MAX SDK'
 s.homepage = "https://github.com/CocoaPods/Specs/search?o=desc&q=#{s.name}&s=indexed"

--- a/AmazonAdMarketplace/CHANGELOG.md
+++ b/AmazonAdMarketplace/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 4.9.3.0
+* Certified with AmazonAdMarketplace SDK 4.9.3.
+* Updated minimum Xcode requirement to 15.0.
+
 ## 4.9.2.0
 * Certified with AmazonAdMarketplace SDK 4.9.2.
 

--- a/BidMachine/AppLovinMediationBidMachineAdapter.podspec
+++ b/BidMachine/AppLovinMediationBidMachineAdapter.podspec
@@ -2,7 +2,7 @@ Pod::Spec.new do |s|
 
 s.authors = 'AppLovin Corporation'
 s.name = 'AppLovinMediationBidMachineAdapter'
-s.version = '2.6.1.0.0'
+s.version = '2.7.0.0.0'
 s.platform = :ios, '12.0'
 s.summary = 'BidMachine adapter used for mediation with the AppLovin MAX SDK'
 s.homepage = "https://github.com/CocoaPods/Specs/search?o=desc&q=#{s.name}&s=indexed"
@@ -26,7 +26,7 @@ s.source =
 
 s.vendored_frameworks = "#{s.name}-#{s.version}/#{s.name}.xcframework"
 
-s.dependency 'BidMachine', '= 2.6.1'
+s.dependency 'BidMachine', '= 2.7.0'
 s.dependency 'AppLovinSDK'
 s.swift_version = '5.1'
 

--- a/BidMachine/BidMachineAdapter/ALBidMachineMediationAdapter.m
+++ b/BidMachine/BidMachineAdapter/ALBidMachineMediationAdapter.m
@@ -8,9 +8,8 @@
 
 #import "ALBidMachineMediationAdapter.h"
 #import <BidMachine/BidMachine.h>
-#import <BidMachineApiCore/BidMachineApiCore.h>
 
-#define ADAPTER_VERSION @"2.6.1.0.0"
+#define ADAPTER_VERSION @"2.7.0.0.0"
 
 @interface ALBidMachineInterstitialDelegate : NSObject <BidMachineAdDelegate>
 @property (nonatomic,   weak) ALBidMachineMediationAdapter *parentAdapter;

--- a/BidMachine/CHANGELOG.md
+++ b/BidMachine/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.7.0.0.0
+* Certified with BidMachine SDK 2.7.0.
+* Updated minimum Xcode requirement to 15.0.
+
 ## 2.6.1.0.0
 * Certified with BidMachine SDK 2.6.1.
 

--- a/BigoAds/AppLovinMediationBigoAdsAdapter.podspec
+++ b/BigoAds/AppLovinMediationBigoAdsAdapter.podspec
@@ -2,7 +2,7 @@ Pod::Spec.new do |s|
 
 s.authors = 'AppLovin Corporation'
 s.name = 'AppLovinMediationBigoAdsAdapter'
-s.version = '4.2.2.0'
+s.version = '4.2.3.0'
 s.platform = :ios, '11.0'
 s.summary = 'Bigo Ads adapter used for mediation with the AppLovin MAX SDK'
 s.homepage = "https://github.com/CocoaPods/Specs/search?o=desc&q=#{s.name}&s=indexed"
@@ -26,7 +26,7 @@ s.source =
 
 s.vendored_frameworks = "#{s.name}-#{s.version}/#{s.name}.xcframework"
 
-s.dependency 'BigoADS', '= 4.2.2'
+s.dependency 'BigoADS', '= 4.2.3'
 s.dependency 'AppLovinSDK', '>= 12.4.1'
 s.swift_version = '5.0'
 

--- a/BigoAds/BigoAdsAdapter/ALBigoAdsMediationAdapter.m
+++ b/BigoAds/BigoAdsAdapter/ALBigoAdsMediationAdapter.m
@@ -14,7 +14,7 @@
 #import <BigoADS/BigoNativeAdLoader.h>
 #import <BigoADS/BigoAdInteractionDelegate.h>
 
-#define ADAPTER_VERSION @"4.2.2.0"
+#define ADAPTER_VERSION @"4.2.3.0"
 
 @interface ALBigoAdsMediationAdapterInterstitialAdDelegate : NSObject <BigoInterstitialAdLoaderDelegate, BigoAdInteractionDelegate>
 @property (nonatomic,   weak) ALBigoAdsMediationAdapter *parentAdapter;

--- a/BigoAds/CHANGELOG.md
+++ b/BigoAds/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 4.2.3.0
+* Certified with BigoAds SDK 4.2.3.
+* Updated minimum Xcode requirement to 15.0.
+
 ## 4.2.2.0
 * Certified with BigoAds SDK 4.2.2.
 

--- a/ByteDance/AppLovinMediationByteDanceAdapter.podspec
+++ b/ByteDance/AppLovinMediationByteDanceAdapter.podspec
@@ -2,7 +2,7 @@ Pod::Spec.new do |s|
 
 s.authors = 'AppLovin Corporation'
 s.name = 'AppLovinMediationByteDanceAdapter'
-s.version = '5.9.0.6.0'
+s.version = '5.9.0.7.0'
 s.platform = :ios, '11.0'
 s.summary = 'ByteDance adapter used for mediation with the AppLovin MAX SDK'
 s.homepage = "https://github.com/CocoaPods/Specs/search?o=desc&q=#{s.name}&s=indexed"
@@ -26,7 +26,7 @@ s.source =
 
 s.vendored_frameworks = "#{s.name}-#{s.version}/#{s.name}.xcframework"
 
-s.dependency 'Ads-Global/BUAdSDK_Compatible', '= 5.9.0.6'
+s.dependency 'Ads-Global/BUAdSDK_Compatible', '= 5.9.0.7'
 s.dependency 'AppLovinSDK'
 s.swift_version = '5.0'
 

--- a/ByteDance/AppLovinMediationByteDanceAdapter.podspec
+++ b/ByteDance/AppLovinMediationByteDanceAdapter.podspec
@@ -2,7 +2,7 @@ Pod::Spec.new do |s|
 
 s.authors = 'AppLovin Corporation'
 s.name = 'AppLovinMediationByteDanceAdapter'
-s.version = '5.9.0.7.0'
+s.version = '5.9.0.8.0'
 s.platform = :ios, '11.0'
 s.summary = 'ByteDance adapter used for mediation with the AppLovin MAX SDK'
 s.homepage = "https://github.com/CocoaPods/Specs/search?o=desc&q=#{s.name}&s=indexed"
@@ -26,7 +26,7 @@ s.source =
 
 s.vendored_frameworks = "#{s.name}-#{s.version}/#{s.name}.xcframework"
 
-s.dependency 'Ads-Global/BUAdSDK_Compatible', '= 5.9.0.7'
+s.dependency 'Ads-Global/BUAdSDK_Compatible', '= 5.9.0.8'
 s.dependency 'AppLovinSDK'
 s.swift_version = '5.0'
 

--- a/ByteDance/ByteDanceAdapter/ALByteDanceMediationAdapter.m
+++ b/ByteDance/ByteDanceAdapter/ALByteDanceMediationAdapter.m
@@ -9,7 +9,7 @@
 #import "ALByteDanceMediationAdapter.h"
 #import <PAGAdSDK/PAGAdSDK.h>
 
-#define ADAPTER_VERSION @"5.9.0.7.0"
+#define ADAPTER_VERSION @"5.9.0.8.0"
 
 @interface ALByteDanceInterstitialAdDelegate : NSObject <PAGLInterstitialAdDelegate>
 @property (nonatomic,   weak) ALByteDanceMediationAdapter *parentAdapter;

--- a/ByteDance/ByteDanceAdapter/ALByteDanceMediationAdapter.m
+++ b/ByteDance/ByteDanceAdapter/ALByteDanceMediationAdapter.m
@@ -9,7 +9,7 @@
 #import "ALByteDanceMediationAdapter.h"
 #import <PAGAdSDK/PAGAdSDK.h>
 
-#define ADAPTER_VERSION @"5.9.0.6.0"
+#define ADAPTER_VERSION @"5.9.0.7.0"
 
 @interface ALByteDanceInterstitialAdDelegate : NSObject <PAGLInterstitialAdDelegate>
 @property (nonatomic,   weak) ALByteDanceMediationAdapter *parentAdapter;

--- a/ByteDance/CHANGELOG.md
+++ b/ByteDance/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 5.9.0.8.0
+* Certified with ByteDance SDK 5.9.0.8.
+
 ## 5.9.0.7.0
 * Certified with ByteDance SDK 5.9.0.7.
 * Updated minimum Xcode requirement to 15.0.

--- a/ByteDance/CHANGELOG.md
+++ b/ByteDance/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 5.9.0.7.0
+* Certified with ByteDance SDK 5.9.0.7.
+* Updated minimum Xcode requirement to 15.0.
+
 ## 5.9.0.6.0
 * Certified with ByteDance SDK 5.9.0.6.
 

--- a/Google/AppLovinMediationGoogleAdapter.podspec
+++ b/Google/AppLovinMediationGoogleAdapter.podspec
@@ -2,7 +2,7 @@ Pod::Spec.new do |s|
 
 s.authors = 'AppLovin Corporation'
 s.name = 'AppLovinMediationGoogleAdapter'
-s.version = '11.3.0.0'
+s.version = '11.4.0.0'
 s.platform = :ios, '12.0'
 s.summary = 'Google adapter used for mediation with the AppLovin MAX SDK'
 s.homepage = "https://github.com/CocoaPods/Specs/search?o=desc&q=#{s.name}&s=indexed"
@@ -26,7 +26,7 @@ s.source =
 
 s.vendored_frameworks = "#{s.name}-#{s.version}/#{s.name}.xcframework"
 
-s.dependency 'Google-Mobile-Ads-SDK', '= 11.3.0'
+s.dependency 'Google-Mobile-Ads-SDK', '= 11.4.0'
 s.dependency 'AppLovinSDK'
 s.swift_version = '5.0'
 

--- a/Google/CHANGELOG.md
+++ b/Google/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 11.4.0.0
+* Certified with Google SDK 11.4.0.
+* Updated minimum Xcode requirement to 15.0.
+
 ## 11.3.0.0
 * Certified with Google SDK 11.3.0.
 

--- a/Google/GoogleAdapter/ALGoogleMediationAdapter.m
+++ b/Google/GoogleAdapter/ALGoogleMediationAdapter.m
@@ -16,7 +16,7 @@
 #import "ALGoogleNativeAdViewDelegate.h"
 #import "ALGoogleNativeAdDelegate.h"
 
-#define ADAPTER_VERSION @"11.3.0.0"
+#define ADAPTER_VERSION @"11.4.0.0"
 
 @interface ALGoogleMediationAdapter ()
 

--- a/GoogleAdManager/AppLovinMediationGoogleAdManagerAdapter.podspec
+++ b/GoogleAdManager/AppLovinMediationGoogleAdManagerAdapter.podspec
@@ -2,7 +2,7 @@ Pod::Spec.new do |s|
 
 s.authors = 'AppLovin Corporation'
 s.name = 'AppLovinMediationGoogleAdManagerAdapter'
-s.version = '11.3.0.0'
+s.version = '11.4.0.0'
 s.platform = :ios, '12.0'
 s.summary = 'Google Ad Manager adapter used for mediation with the AppLovin MAX SDK'
 s.homepage = "https://github.com/CocoaPods/Specs/search?o=desc&q=#{s.name}&s=indexed"
@@ -26,7 +26,7 @@ s.source =
 
 s.vendored_frameworks = "#{s.name}-#{s.version}/#{s.name}.xcframework"
 
-s.dependency 'Google-Mobile-Ads-SDK', '= 11.3.0'
+s.dependency 'Google-Mobile-Ads-SDK', '= 11.4.0'
 s.dependency 'AppLovinSDK'
 s.swift_version = '5.0'
 

--- a/GoogleAdManager/CHANGELOG.md
+++ b/GoogleAdManager/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 11.4.0.0
+* Certified with GoogleAdManager SDK 11.4.0.
+* Updated minimum Xcode requirement to 15.0.
+
 ## 11.3.0.0
 * Certified with GoogleAdManager SDK 11.3.0.
 

--- a/GoogleAdManager/GoogleAdManagerAdapter/ALGoogleAdManagerMediationAdapter.m
+++ b/GoogleAdManager/GoogleAdManagerAdapter/ALGoogleAdManagerMediationAdapter.m
@@ -9,7 +9,7 @@
 #import "ALGoogleAdManagerMediationAdapter.h"
 #import <GoogleMobileAds/GoogleMobileAds.h>
 
-#define ADAPTER_VERSION @"11.3.0.0"
+#define ADAPTER_VERSION @"11.4.0.0"
 
 #define TITLE_LABEL_TAG          1
 #define MEDIA_VIEW_CONTAINER_TAG 2

--- a/Mintegral/AppLovinMediationMintegralAdapter.podspec
+++ b/Mintegral/AppLovinMediationMintegralAdapter.podspec
@@ -2,7 +2,7 @@ Pod::Spec.new do |s|
 
 s.authors = 'AppLovin Corporation'
 s.name = 'AppLovinMediationMintegralAdapter'
-s.version = '7.6.3.0.0'
+s.version = '7.6.4.0.0'
 s.platform = :ios, '11.0'
 s.summary = 'Mintegral adapter used for mediation with the AppLovin MAX SDK'
 s.homepage = "https://github.com/CocoaPods/Specs/search?o=desc&q=#{s.name}&s=indexed"
@@ -26,8 +26,8 @@ s.source =
 
 s.vendored_frameworks = "#{s.name}-#{s.version}/#{s.name}.xcframework"
 
-s.dependency 'MintegralAdSDK', '= 7.6.3'
-s.dependency 'MintegralAdSDK/BidSplashAd', '= 7.6.3'
+s.dependency 'MintegralAdSDK', '= 7.6.4'
+s.dependency 'MintegralAdSDK/BidSplashAd', '= 7.6.4'
 
 s.dependency 'AppLovinSDK'
 s.swift_version = '5.0'

--- a/Mintegral/CHANGELOG.md
+++ b/Mintegral/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 7.6.4.0.0
+* Certified with Mintegral SDK 7.6.4.
+* Updated minimum Xcode requirement to 15.0.
+
 ## 7.6.3.0.0
 * Certified with Mintegral SDK 7.6.3.
 

--- a/Mintegral/MintegralAdapter/ALMintegralMediationAdapter.m
+++ b/Mintegral/MintegralAdapter/ALMintegralMediationAdapter.m
@@ -16,7 +16,7 @@
 #import <MTGSDKBanner/MTGBannerAdViewDelegate.h>
 #import <MTGSDKSplash/MTGSplashAD.h>
 
-#define ADAPTER_VERSION @"7.6.3.0.0"
+#define ADAPTER_VERSION @"7.6.4.0.0"
 
 // List of Mintegral error codes not defined in API, but in their docs
 //

--- a/OguryPresage/AppLovinMediationOguryPresageAdapter.podspec
+++ b/OguryPresage/AppLovinMediationOguryPresageAdapter.podspec
@@ -2,7 +2,7 @@ Pod::Spec.new do |s|
 
 s.authors = 'AppLovin Corporation'
 s.name = 'AppLovinMediationOguryPresageAdapter'
-s.version = '4.2.3.1'
+s.version = '4.3.0.0'
 s.platform = :ios, '11.0'
 s.summary = 'Ogury (Presage) adapter used for mediation with the AppLovin MAX SDK'
 s.homepage = "https://github.com/CocoaPods/Specs/search?o=desc&q=#{s.name}&s=indexed"
@@ -26,7 +26,7 @@ s.source =
 
 s.vendored_frameworks = "#{s.name}-#{s.version}/#{s.name}.xcframework"
 
-s.dependency 'OgurySdk', '= 4.2.3'
+s.dependency 'OgurySdk', '= 4.3.0'
 s.dependency 'AppLovinSDK'
 s.swift_version = '5.0' 
 

--- a/OguryPresage/CHANGELOG.md
+++ b/OguryPresage/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 4.3.0.0
+* Certified with OguryPresage SDK 4.3.0.
+* Updated minimum Xcode requirement to 15.0.
+
 ## 4.2.3.1
 * Remove privacy method calls as `[OguryChoiceManagerExternal setTransparencyAndConsentStatus:]` is deprecated and [OguryPresage SDK can collect TCF string directly from disk](https://ogury-ltd.gitbook.io/ios/ogury-choice-manager/third-party-consent-manager#case-a-your-cmp-is-compatible-with-the-iab-gdpr-consent-framework).
 * Remove deprecated callbacks `didStartRewardedAdVideo` and `didCompleteRewardedAdVideo`.

--- a/OguryPresage/OguryPresageAdapter.xcodeproj/project.pbxproj
+++ b/OguryPresage/OguryPresageAdapter.xcodeproj/project.pbxproj
@@ -342,6 +342,7 @@
 			baseConfigurationReference = 7D8C6C8F14CA72A51A0404F5 /* Pods-OguryPresageAdapter.debug.xcconfig */;
 			buildSettings = {
 				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
+				CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES = YES;
 				CODE_SIGN_STYLE = Manual;
 				DEAD_CODE_STRIPPING = NO;
 				DEVELOPMENT_TEAM = X8JXXK4FF5;
@@ -372,6 +373,7 @@
 			baseConfigurationReference = 4889DE7D0A8A2242447E68A0 /* Pods-OguryPresageAdapter.release.xcconfig */;
 			buildSettings = {
 				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
+				CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES = YES;
 				CODE_SIGN_STYLE = Manual;
 				DEAD_CODE_STRIPPING = NO;
 				DEVELOPMENT_TEAM = X8JXXK4FF5;

--- a/OguryPresage/OguryPresageAdapter/ALOguryPresageMediationAdapter.m
+++ b/OguryPresage/OguryPresageAdapter/ALOguryPresageMediationAdapter.m
@@ -11,7 +11,7 @@
 #import <OguryAds/OguryAds.h>
 #import <OguryChoiceManager/OguryChoiceManager.h>
 
-#define ADAPTER_VERSION @"4.2.3.1"
+#define ADAPTER_VERSION @"4.3.0.0"
 
 @interface ALOguryPresageMediationAdapterInterstitialDelegate : NSObject <OguryInterstitialAdDelegate>
 @property (nonatomic,   weak) ALOguryPresageMediationAdapter *parentAdapter;

--- a/TencentGDT/AppLovinMediationTencentGDTAdapter.podspec
+++ b/TencentGDT/AppLovinMediationTencentGDTAdapter.podspec
@@ -2,7 +2,7 @@ Pod::Spec.new do |s|
 
 s.authors = 'AppLovin Corporation'
 s.name = 'AppLovinMediationTencentGDTAdapter'
-s.version = '4.14.71.0'
+s.version = '4.14.76.0'
 s.platform = :ios, '11.0'
 s.summary = 'TencentGDT adapter used for mediation with the AppLovin MAX SDK'
 s.homepage = "https://github.com/CocoaPods/Specs/search?o=desc&q=#{s.name}&s=indexed"
@@ -26,7 +26,7 @@ s.source =
 
 s.vendored_frameworks = "#{s.name}-#{s.version}/#{s.name}.xcframework"
 
-s.dependency 'GDTMobSDK', '= 4.14.71'
+s.dependency 'GDTMobSDK', '= 4.14.76'
 s.dependency 'AppLovinSDK'
 s.swift_version = '5.0'
 

--- a/TencentGDT/CHANGELOG.md
+++ b/TencentGDT/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 4.14.76.0
+* Certified with TencentGDT SDK 4.14.76.
+* Updated minimum Xcode requirement to 15.0.
+* Updated deprecated APIs.
+
 ## 4.14.71.0
 * Certified with TencentGDT SDK 4.14.71.
 * Remove deprecated callbacks `didStartRewardedAdVideo` and `didCompleteRewardedAdVideo`.

--- a/Vungle/AppLovinMediationVungleAdapter.podspec
+++ b/Vungle/AppLovinMediationVungleAdapter.podspec
@@ -2,7 +2,7 @@ Pod::Spec.new do |s|
 
 s.authors = 'AppLovin Corporation'
 s.name = 'AppLovinMediationVungleAdapter'
-s.version = '7.3.1.0'
+s.version = '7.3.2.0'
 s.platform = :ios, '12.0'
 s.summary = 'Vungle adapter used for mediation with the AppLovin MAX SDK'
 s.homepage = "https://github.com/CocoaPods/Specs/search?o=desc&q=#{s.name}&s=indexed"
@@ -26,7 +26,7 @@ s.source =
 
 s.vendored_frameworks = "#{s.name}-#{s.version}/#{s.name}.xcframework"
 
-s.dependency 'VungleAds', '= 7.3.1'
+s.dependency 'VungleAds', '= 7.3.2'
 s.dependency 'AppLovinSDK'
 s.swift_version = '5.0'
 

--- a/Vungle/CHANGELOG.md
+++ b/Vungle/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 7.3.2.0
+* Certified with Vungle SDK 7.3.2.
+* Updated minimum Xcode requirement to 15.0.
+
 ## 7.3.1.0
 * Certified with Vungle SDK 7.3.1.
 * Remove deprecated callbacks `didStartRewardedAdVideo` and `didCompleteRewardedAdVideo`.

--- a/Vungle/VungleAdapter/ALVungleMediationAdapter.m
+++ b/Vungle/VungleAdapter/ALVungleMediationAdapter.m
@@ -9,7 +9,7 @@
 #import "ALVungleMediationAdapter.h"
 #import <VungleAdsSDK/VungleAdsSDK.h>
 
-#define ADAPTER_VERSION @"7.3.1.0"
+#define ADAPTER_VERSION @"7.3.2.0"
 
 @interface ALVungleMediationAdapterInterstitialAdDelegate : NSObject <VungleInterstitialDelegate>
 @property (nonatomic,   weak) ALVungleMediationAdapter *parentAdapter;

--- a/Vungle/VungleAdapter/ALVungleMediationAdapter.m
+++ b/Vungle/VungleAdapter/ALVungleMediationAdapter.m
@@ -113,7 +113,7 @@ static MAAdapterInitializationStatus ALVungleIntializationStatus = NSIntegerMin;
 {
     [self updateUserPrivacySettingsForParameters: parameters];
     
-    if ( [ALVungleInitialized compareAndSet: NO update: YES] )
+    if ( ![ALVungleInitialized get] && ALVungleIntializationStatus != MAAdapterInitializationStatusInitializing )
     {
         ALVungleIntializationStatus = MAAdapterInitializationStatusInitializing;
         
@@ -134,7 +134,7 @@ static MAAdapterInitializationStatus ALVungleIntializationStatus = NSIntegerMin;
             else
             {
                 [self log: @"Vungle SDK initialized"];
-                
+                [ALVungleInitialized compareAndSet: NO update: YES]
                 ALVungleIntializationStatus = MAAdapterInitializationStatusInitializedSuccess;
                 completionHandler(ALVungleIntializationStatus, nil);
             }

--- a/Vungle/VungleAdapter/ALVungleMediationAdapter.m
+++ b/Vungle/VungleAdapter/ALVungleMediationAdapter.m
@@ -134,7 +134,7 @@ static MAAdapterInitializationStatus ALVungleIntializationStatus = NSIntegerMin;
             else
             {
                 [self log: @"Vungle SDK initialized"];
-                [ALVungleInitialized compareAndSet: NO update: YES]
+                [ALVungleInitialized compareAndSet: NO update: YES];
                 ALVungleIntializationStatus = MAAdapterInitializationStatusInitializedSuccess;
                 completionHandler(ALVungleIntializationStatus, nil);
             }

--- a/Yandex/AppLovinMediationYandexAdapter.podspec
+++ b/Yandex/AppLovinMediationYandexAdapter.podspec
@@ -2,7 +2,7 @@ Pod::Spec.new do |s|
 
 s.authors = 'AppLovin Corporation'
 s.name = 'AppLovinMediationYandexAdapter'
-s.version = '6.1.0.3'
+s.version = '7.0.0.0'
 s.platform = :ios, '13.0'
 s.summary = 'Yandex adapter used for mediation with the AppLovin MAX SDK'
 s.homepage = "https://github.com/CocoaPods/Specs/search?o=desc&q=#{s.name}&s=indexed"
@@ -26,14 +26,14 @@ s.source =
 
 s.vendored_frameworks = "#{s.name}-#{s.version}/#{s.name}.xcframework"
 
-s.dependency 'YandexMobileAds', '= 6.1.0'
-# Newer versions of DivKit do not work with YandexMobileAds. Try to remove this when updating Yandex.
-s.dependency 'DivKit', '= 28.4.0'
-# Newer versions of VGSL don't work with YandexMobileAds. Try to remove this when updating Yandex.
-s.dependency 'VGSLCommonCore', '= 2.3.0'
-s.dependency 'VGSLNetworking', '= 2.3.0'
+s.dependency 'YandexMobileAds', '= 7.0.0'
 s.dependency 'AppLovinSDK'
-s.swift_version = '5.7'
+s.swift_version = '5.9'
+
+s.pod_target_xcconfig =
+{
+  'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'x86_64'
+}
 
 s.description = <<-DESC
 

--- a/Yandex/CHANGELOG.md
+++ b/Yandex/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 7.0.0.0
+* Certified with Yandex SDK 7.0.0.
+* Update to use new APIs for signal collection and SDK version retrieval.
+* Update to use new impression callback, `didTrackImpressionWith:`, for rewarded ads.
+* Remove deprecated callbacks `didStartRewardedAdVideo` and `didCompleteRewardedAdVideo`.
+* Updated minimum Xcode requirement to 15.0.
+
 ## 6.1.0.3
 * Specified compatible version of Yandex dependency for republished SDK 6.1.0: VGSLCommonCore and VGSLNetworking (2.3.0).
 

--- a/Yandex/YandexAdapter.xcodeproj/project.pbxproj
+++ b/Yandex/YandexAdapter.xcodeproj/project.pbxproj
@@ -302,6 +302,7 @@
 				DEAD_CODE_STRIPPING = NO;
 				DEVELOPMENT_TEAM = X8JXXK4FF5;
 				ENABLE_BITCODE = NO;
+				EXCLUDED_ARCHS = x86_64;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$PROJECT_DIR/../../iOS-Workspace/Pods/**",
 					"$(inherited)",
@@ -329,6 +330,7 @@
 				DEAD_CODE_STRIPPING = NO;
 				DEVELOPMENT_TEAM = X8JXXK4FF5;
 				ENABLE_BITCODE = NO;
+				EXCLUDED_ARCHS = x86_64;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$PROJECT_DIR/../../iOS-Workspace/Pods/**",
 					"$(inherited)",


### PR DESCRIPTION
This commit reverts previous change to init and instead removes the
VungleAds init check in all ad type load events. This PR should be
reviewed in conjunction with changes in the IOS-6810 branch in the
VungleAdsSDK repo.

By removing the init check, the adapter can all load for all ad types
no matter if the SDK is initialized or not - in the event the SDK init
previously failed, this will allow for the SDK to retry the init as part of
the load event. If the init fails, the ad load will fail with an SDK not
initialized error. If the init passes, the ad load will continue. The adapter
has been updated so that the initialization status can be updated
during the ad load or ad load failure callbacks.

IOS-6810