### PR TITLE
[IOS-7769] Fixed wrong delegate callback methods

### DIFF
--- a/Vungle/VungleAdapter/ALVungleMediationAdapter.m
+++ b/Vungle/VungleAdapter/ALVungleMediationAdapter.m
@@ -1091,13 +1091,6 @@ static MAAdapterInitializationStatus ALVungleIntializationStatus = NSIntegerMin;
     [self.delegate didFailToLoadAdViewAdWithError: adapterError];
 }
 
-- (void)nativeAdDidFailToPresent:(VungleNative *)native withError:(NSError *)error
-{
-    MAAdapterError *adapterError = [ALVungleMediationAdapter toMaxError: error isAdPresentError: NO];
-    [self.parentAdapter log: @"Native %@ ad failed to present with error: %@", self.adFormat, adapterError];
-    [self.delegate didFailToLoadAdViewAdWithError: adapterError];
-}
-
 - (void)nativeAdDidTrackImpression:(VungleNative *)nativeAd
 {
     [self.parentAdapter log: @"Native %@ ad shown: %@", self.adFormat, self.placementIdentifier];
@@ -1180,13 +1173,6 @@ static MAAdapterInitializationStatus ALVungleIntializationStatus = NSIntegerMin;
 {
     MAAdapterError *adapterError = [ALVungleMediationAdapter toMaxError: error isAdPresentError: NO];
     [self.parentAdapter log: @"Native ad failed to load with error: %@", adapterError];
-    [self.delegate didFailToLoadNativeAdWithError: adapterError];
-}
-
-- (void)nativeAdDidFailToPresent:(VungleNative *)native withError:(NSError *)error
-{
-    MAAdapterError *adapterError = [ALVungleMediationAdapter toMaxError: error isAdPresentError: NO];
-    [self.parentAdapter log: @"Native ad failed to present with error: %@", adapterError];
     [self.delegate didFailToLoadNativeAdWithError: adapterError];
 }
 

--- a/Vungle/VungleAdapter/ALVungleMediationAdapter.m
+++ b/Vungle/VungleAdapter/ALVungleMediationAdapter.m
@@ -1084,10 +1084,17 @@ static MAAdapterInitializationStatus ALVungleIntializationStatus = NSIntegerMin;
     });
 }
 
-- (void)nativeAd:(VungleNative *)nativeAd didFailWithError:(NSError *)error
+- (void)nativeAdDidFailToLoad:(VungleNative *)native withError:(NSError *)error
 {
     MAAdapterError *adapterError = [ALVungleMediationAdapter toMaxError: error isAdPresentError: NO];
     [self.parentAdapter log: @"Native %@ ad failed to load with error: %@", self.adFormat, adapterError];
+    [self.delegate didFailToLoadAdViewAdWithError: adapterError];
+}
+
+- (void)nativeAdDidFailToPresent:(VungleNative *)native withError:(NSError *)error
+{
+    MAAdapterError *adapterError = [ALVungleMediationAdapter toMaxError: error isAdPresentError: NO];
+    [self.parentAdapter log: @"Native %@ ad failed to present with error: %@", self.adFormat, adapterError];
     [self.delegate didFailToLoadAdViewAdWithError: adapterError];
 }
 
@@ -1169,10 +1176,17 @@ static MAAdapterInitializationStatus ALVungleIntializationStatus = NSIntegerMin;
     });
 }
 
-- (void)nativeAd:(VungleNative *)nativeAd didFailWithError:(NSError *)error
+- (void)nativeAdDidFailToLoad:(VungleNative *)native withError:(NSError *)error
 {
     MAAdapterError *adapterError = [ALVungleMediationAdapter toMaxError: error isAdPresentError: NO];
     [self.parentAdapter log: @"Native ad failed to load with error: %@", adapterError];
+    [self.delegate didFailToLoadNativeAdWithError: adapterError];
+}
+
+- (void)nativeAdDidFailToPresent:(VungleNative *)native withError:(NSError *)error
+{
+    MAAdapterError *adapterError = [ALVungleMediationAdapter toMaxError: error isAdPresentError: NO];
+    [self.parentAdapter log: @"Native ad failed to present with error: %@", adapterError];
     [self.delegate didFailToLoadNativeAdWithError: adapterError];
 }
 


### PR DESCRIPTION
This commit will fix the wrong delegate callback methods below.

In `ALVungleMediationAdapterNativeAdViewDelegate` and `ALVungleMediationAdapterNativeAdDelegate`,

`(void)nativeAd:(VungleNative *)nativeAd didFailWithError:(NSError *)error`
should be
`(void)nativeAdDidFailToLoad:(VungleNative *)native withError:(NSError *)error`

[IOS-7769](https://vungle.atlassian.net/browse/IOS-7769)

[IOS-7769]: https://vungle.atlassian.net/browse/IOS-7769?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ