### PR TITLE
[IOS-7623] Adapter Logging

### DIFF
--- a/Vungle/VungleAdapter/ALVungleMediationAdapter.m
+++ b/Vungle/VungleAdapter/ALVungleMediationAdapter.m
@@ -9,7 +9,7 @@
 #import "ALVungleMediationAdapter.h"
 #import <VungleAdsSDK/VungleAdsSDK.h>
 
-#define ADAPTER_VERSION @"7.7.0.0"
+#define ADAPTER_VERSION @"7.7.1.0"
 
 @interface ALVungleMediationAdapterInterstitialAdDelegate : NSObject <VungleInterstitialDelegate>
 @property (nonatomic,   weak) ALVungleMediationAdapter *parentAdapter;

--- a/Vungle/VungleAdapter/ALVungleMediationAdapter.m
+++ b/Vungle/VungleAdapter/ALVungleMediationAdapter.m
@@ -387,17 +387,8 @@ static MAAdapterInitializationStatus ALVungleIntializationStatus = NSIntegerMin;
                                                                                               andNotify: delegate];
         self.adViewAd.delegate = self.adViewAdDelegate;
         self.adViewAd.adapterAdFormat = @"MAAdViewAdapter";
-        if ( [self isAdaptiveAdViewForBannerPlacement: parameters]) {
-            NSString *adaptiveType = [parameters.localExtraParameters al_stringForKey:@"adaptive_banner_type" defaultValue:@"adaptive"];
-            self.adViewAd.adapterAdFormat = [NSString stringWithFormat:@"MAAdViewAdapter-%@", adaptiveType];
-            // This is the case in which AdUnit is set to "adaptive", but Placement is not inline.
-            NSNumber *adaptiveWidth = [parameters.localExtraParameters al_numberForKey: @"adaptive_banner_width"];
-            NSNumber *adaptiveMaxHeight = [parameters.localExtraParameters al_numberForKey: @"inline_adaptive_banner_max_height"];
-            NSString *adaptiveSizeMessage = [NSString stringWithFormat: @"AdaptiveBannerSizeMismatch:w-%@|maxh-%@",
-                                             adaptiveWidth ?: @"unknown",
-                                             adaptiveMaxHeight ?: @"unknown"];
-            [VungleMediationLogger logErrorForAd:self.adViewAd message:adaptiveSizeMessage];
-        }
+        [self logAdaptiveAdViewForBannerPlacement: parameters adViewAd:self.adViewAd];
+
 
         [self.adViewAd load: bidResponse];
     }
@@ -456,16 +447,23 @@ static MAAdapterInitializationStatus ALVungleIntializationStatus = NSIntegerMin;
     }
 }
 
-- (BOOL)isAdaptiveAdViewForBannerPlacement:(id<MAAdapterResponseParameters>)parameters
+- (void)logAdaptiveAdViewForBannerPlacement:(id<MAAdapterResponseParameters>)parameters adViewAd:(VungleBannerView *)adViewAd
 {
     BOOL isAdaptiveServerParams = [parameters.serverParameters al_boolForKey: @"adaptive_banner"];
     BOOL isAdaptiveLocalParams = [parameters.localExtraParameters al_boolForKey: @"adaptive_banner"];
     BOOL isInlinePlacement = [VungleAds isInLine: parameters.thirdPartyAdPlacementIdentifier];
-    
+
     if ( ( isAdaptiveServerParams || isAdaptiveLocalParams ) && !isInlinePlacement ) {
-        return YES;
+        NSString *adaptiveType = [parameters.localExtraParameters al_stringForKey:@"adaptive_banner_type" defaultValue:@"adaptive"];
+        adViewAd.adapterAdFormat = [NSString stringWithFormat:@"MAAdViewAdapter-%@", adaptiveType];
+        // This is the case in which AdUnit is set to "adaptive", but Placement is not inline.
+        NSNumber *adaptiveWidth = [parameters.localExtraParameters al_numberForKey: @"adaptive_banner_width"];
+        NSNumber *adaptiveMaxHeight = [parameters.localExtraParameters al_numberForKey: @"inline_adaptive_banner_max_height"];
+        NSString *adaptiveSizeMessage = [NSString stringWithFormat: @"AdaptiveBannerSizeMismatch:w-%@|maxh-%@",
+                                         adaptiveWidth ?: @"unknown",
+                                         adaptiveMaxHeight ?: @"unknown"];
+        [VungleMediationLogger logErrorForAd:adViewAd message:adaptiveSizeMessage];
     }
-    return NO;
 }
 
 - (void)updateUserPrivacySettingsForParameters:(id<MAAdapterParameters>)parameters

--- a/Vungle/VungleAdapter/ALVungleMediationAdapter.m
+++ b/Vungle/VungleAdapter/ALVungleMediationAdapter.m
@@ -87,7 +87,6 @@
 // AdView
 @property (nonatomic, strong) VungleBannerView *adViewAd;
 @property (nonatomic, strong) ALVungleMediationAdapterAdViewAdDelegate *adViewAdDelegate;
-@property (nonatomic, assign) BOOL isAdViewNative;
 
 // Native Ad
 @property (nonatomic, strong) VungleNative *nativeAd;

--- a/Vungle/VungleAdapter/ALVungleMediationAdapter.m
+++ b/Vungle/VungleAdapter/ALVungleMediationAdapter.m
@@ -467,6 +467,7 @@ static MAAdapterInitializationStatus ALVungleIntializationStatus = NSIntegerMin;
     }
     return NO;
 }
+
 - (void)updateUserPrivacySettingsForParameters:(id<MAAdapterParameters>)parameters
 {
     NSNumber *hasUserConsent = [parameters hasUserConsent];

--- a/Vungle/VungleAdapter/ALVungleMediationAdapter.m
+++ b/Vungle/VungleAdapter/ALVungleMediationAdapter.m
@@ -427,10 +427,10 @@ static MAAdapterInitializationStatus ALVungleIntializationStatus = NSIntegerMin;
 
 - (BOOL)isAdaptiveAdViewEnabledForParameters:(id<MAAdapterResponseParameters>)parameters
 {
-    BOOL isAdaptiveSeverParams = [parameters.serverParameters al_boolForKey: @"adaptive_banner"];
+    BOOL isAdaptiveServerParams = [parameters.serverParameters al_boolForKey: @"adaptive_banner"];
     BOOL isAdaptiveLocalParams = [parameters.localExtraParameters al_boolForKey: @"adaptive_banner"];
     
-    if ( !isAdaptiveSeverParams && !isAdaptiveLocalParams ) {
+    if ( !isAdaptiveServerParams && !isAdaptiveLocalParams ) {
         return NO;
     }
     

--- a/Vungle/VungleAdapter/ALVungleMediationAdapter.m
+++ b/Vungle/VungleAdapter/ALVungleMediationAdapter.m
@@ -87,6 +87,7 @@
 // AdView
 @property (nonatomic, strong) VungleBannerView *adViewAd;
 @property (nonatomic, strong) ALVungleMediationAdapterAdViewAdDelegate *adViewAdDelegate;
+@property (nonatomic, assign) BOOL isAdViewNative;
 
 // Native Ad
 @property (nonatomic, strong) VungleNative *nativeAd;
@@ -364,7 +365,7 @@ static MAAdapterInitializationStatus ALVungleIntializationStatus = NSIntegerMin;
                                                                                                          format: adFormat
                                                                                                      parameters: parameters
                                                                                                       andNotify: delegate];
-        [self loadVungleNativeAdForParameters: parameters andNotify: self.nativeAdViewDelegate];
+        [self loadVungleNativeAdForParameters: parameters andNotify: self.nativeAdViewDelegate isAdViewNative: YES];
     }
     else
     {
@@ -387,7 +388,18 @@ static MAAdapterInitializationStatus ALVungleIntializationStatus = NSIntegerMin;
                                                                                               andNotify: delegate];
         self.adViewAd.delegate = self.adViewAdDelegate;
         self.adViewAd.adapterAdFormat = @"MAAdViewAdapter";
-        
+        if ( [self isAdaptiveAdViewForBannerPlacement: parameters]) {
+            NSString *adaptiveType = [parameters.localExtraParameters al_stringForKey:@"adaptive_banner_type" defaultValue:@"adaptive"];
+            self.adViewAd.adapterAdFormat = [NSString stringWithFormat:@"MAAdViewAdapter-%@", adaptiveType];
+            // This is the case in which AdUnit is set to "adaptive", but Placement is not inline.
+            NSNumber *adaptiveWidth = [parameters.localExtraParameters al_numberForKey: @"adaptive_banner_width"];
+            NSNumber *adaptiveMaxHeight = [parameters.localExtraParameters al_numberForKey: @"inline_adaptive_banner_max_height"];
+            NSString *adaptiveSizeMessage = [NSString stringWithFormat: @"AdaptiveBannerSizeMismatch:w-%@|maxh-%@",
+                                             adaptiveWidth ?: @"unknown",
+                                             adaptiveMaxHeight ?: @"unknown"];
+            [VungleMediationLogger logErrorForAd:self.adViewAd message:adaptiveSizeMessage];
+        }
+
         [self.adViewAd load: bidResponse];
     }
 }
@@ -415,7 +427,7 @@ static MAAdapterInitializationStatus ALVungleIntializationStatus = NSIntegerMin;
     self.nativeAdDelegate = [[ALVungleMediationAdapterNativeAdDelegate alloc] initWithParentAdapter: self
                                                                                          parameters: parameters
                                                                                           andNotify: delegate];
-    [self loadVungleNativeAdForParameters: parameters andNotify: self.nativeAdDelegate];
+    [self loadVungleNativeAdForParameters: parameters andNotify: self.nativeAdDelegate isAdViewNative: NO];
 }
 
 #pragma mark - Shared Methods
@@ -440,21 +452,22 @@ static MAAdapterInitializationStatus ALVungleIntializationStatus = NSIntegerMin;
     }
     else
     {
-        // This is the case in which AdUnit is set to "adaptive", but Placement is not inline.
-        NSString *placementId = parameters.thirdPartyAdPlacementIdentifier;
-        NSNumber *adaptiveWidth = [parameters.localExtraParameters al_numberForKey: @"adaptive_banner_width"];
-        NSNumber *adaptiveMaxHeight = [parameters.localExtraParameters al_numberForKey: @"inline_adaptive_banner_max_height"];
-        NSString *adaptiveSizeMessage = [NSString stringWithFormat: @"AdaptiveBannerSizeMismatch:pid-%@|w-%@|maxh-%@",
-                                         placementId ?: @"unknown",
-                                         adaptiveWidth ?: @"unknown",
-                                         adaptiveMaxHeight ?: @"unknown"];
-        [VungleMediationLogger logErrorForAd:nil message:adaptiveSizeMessage];
-        
         [self userError: @"Please use a Vungle inline placement ID in order to use Vungle adaptive ads"];
         return NO;
     }
 }
 
+- (BOOL)isAdaptiveAdViewForBannerPlacement:(id<MAAdapterResponseParameters>)parameters
+{
+    BOOL isAdaptiveServerParams = [parameters.serverParameters al_boolForKey: @"adaptive_banner"];
+    BOOL isAdaptiveLocalParams = [parameters.localExtraParameters al_boolForKey: @"adaptive_banner"];
+    BOOL isInlinePlacement = [VungleAds isInLine: parameters.thirdPartyAdPlacementIdentifier];
+    
+    if ( ( isAdaptiveServerParams || isAdaptiveLocalParams ) && !isInlinePlacement ) {
+        return YES;
+    }
+    return NO;
+}
 - (void)updateUserPrivacySettingsForParameters:(id<MAAdapterParameters>)parameters
 {
     NSNumber *hasUserConsent = [parameters hasUserConsent];
@@ -471,7 +484,7 @@ static MAAdapterInitializationStatus ALVungleIntializationStatus = NSIntegerMin;
     }
 }
 
-- (void)loadVungleNativeAdForParameters:(id<MAAdapterResponseParameters>)parameters andNotify:(id<VungleNativeDelegate>)delegate
+- (void)loadVungleNativeAdForParameters:(id<MAAdapterResponseParameters>)parameters andNotify:(id<VungleNativeDelegate>)delegate isAdViewNative:(BOOL)isAdViewNative
 {
     NSString *placementIdentifier = parameters.thirdPartyAdPlacementIdentifier;
     NSString *bidResponse = parameters.bidResponse;
@@ -479,7 +492,7 @@ static MAAdapterInitializationStatus ALVungleIntializationStatus = NSIntegerMin;
     self.nativeAd = [[VungleNative alloc] initWithPlacementId: placementIdentifier];
     self.nativeAd.delegate = delegate;
     self.nativeAd.adOptionsPosition = NativeAdOptionsPositionTopRight;
-    self.nativeAd.adapterAdFormat = @"MANativeAdAdapter";
+    self.nativeAd.adapterAdFormat = isAdViewNative ? @"MANativeAdAdapter-adView" : @"MANativeAdAdapter";
     [self.nativeAd load: bidResponse];
 }
 

--- a/Vungle/VungleAdapter/ALVungleMediationAdapter.m
+++ b/Vungle/VungleAdapter/ALVungleMediationAdapter.m
@@ -490,7 +490,7 @@ static MAAdapterInitializationStatus ALVungleIntializationStatus = NSIntegerMin;
     self.nativeAd = [[VungleNative alloc] initWithPlacementId: placementIdentifier];
     self.nativeAd.delegate = delegate;
     self.nativeAd.adOptionsPosition = NativeAdOptionsPositionTopRight;
-    self.nativeAd.adapterAdFormat = isAdViewNative ? @"MANativeAdAdapter-adView" : @"MANativeAdAdapter";
+    self.nativeAd.adapterAdFormat = isAdViewNative ? @"MANativeAdAdapter-banner" : @"MANativeAdAdapter";
     [self.nativeAd load: bidResponse];
 }
 

--- a/Vungle/VungleAdapter/ALVungleMediationAdapter.m
+++ b/Vungle/VungleAdapter/ALVungleMediationAdapter.m
@@ -219,6 +219,7 @@ static MAAdapterInitializationStatus ALVungleIntializationStatus = NSIntegerMin;
     self.interstitialAd = [[VungleInterstitial alloc] initWithPlacementId: placementIdentifier];
     self.interstitialAdDelegate = [[ALVungleMediationAdapterInterstitialAdDelegate alloc] initWithParentAdapter: self andNotify: delegate];
     self.interstitialAd.delegate = self.interstitialAdDelegate;
+    self.interstitialAd.adapterAdFormat = @"MAInterstitialAdapter";
     
     [self.interstitialAd load: bidResponse];
 }
@@ -263,6 +264,7 @@ static MAAdapterInitializationStatus ALVungleIntializationStatus = NSIntegerMin;
     self.appOpenAdDelegate = [[ALVungleMediationAdapterAppOpenAdDelegate alloc] initWithParentAdapter: self andNotify: delegate];
     self.appOpenAd = [[VungleInterstitial alloc] initWithPlacementId: placementIdentifier];
     self.appOpenAd.delegate = self.appOpenAdDelegate;
+    self.appOpenAd.adapterAdFormat = @"MAAppOpenAdapter";
     
     [self.appOpenAd load: bidResponse];
 }
@@ -307,6 +309,7 @@ static MAAdapterInitializationStatus ALVungleIntializationStatus = NSIntegerMin;
     self.rewardedAd = [[VungleRewarded alloc] initWithPlacementId: placementIdentifier];
     self.rewardedAdDelegate = [[ALVungleMediationAdapterRewardedAdDelegate alloc] initWithParentAdapter: self andNotify: delegate];
     self.rewardedAd.delegate = self.rewardedAdDelegate;
+    self.rewardedAd.adapterAdFormat = @"MARewardedAdapter";
     
     [self.rewardedAd load: bidResponse];
 }
@@ -383,6 +386,7 @@ static MAAdapterInitializationStatus ALVungleIntializationStatus = NSIntegerMin;
                                                                                              parameters: parameters
                                                                                               andNotify: delegate];
         self.adViewAd.delegate = self.adViewAdDelegate;
+        self.adViewAd.adapterAdFormat = @"MAAdViewAdapter";
         
         [self.adViewAd load: bidResponse];
     }
@@ -423,7 +427,12 @@ static MAAdapterInitializationStatus ALVungleIntializationStatus = NSIntegerMin;
 
 - (BOOL)isAdaptiveAdViewEnabledForParameters:(id<MAAdapterResponseParameters>)parameters
 {
-    if ( ![parameters.serverParameters al_boolForKey: @"adaptive_banner"] ) return NO;
+    BOOL isAdaptiveSeverParams = [parameters.serverParameters al_boolForKey: @"adaptive_banner"];
+    BOOL isAdaptiveLocalParams = [parameters.localExtraParameters al_boolForKey: @"adaptive_banner"];
+    
+    if ( !isAdaptiveSeverParams && !isAdaptiveLocalParams ) {
+        return NO;
+    }
     
     if ( [VungleAds isInLine: parameters.thirdPartyAdPlacementIdentifier] )
     {
@@ -431,6 +440,16 @@ static MAAdapterInitializationStatus ALVungleIntializationStatus = NSIntegerMin;
     }
     else
     {
+        // This is the case in which AdUnit is set to "adaptive", but Placement is not inline.
+        NSString *placementId = parameters.thirdPartyAdPlacementIdentifier;
+        NSNumber *adaptiveWidth = [parameters.localExtraParameters al_numberForKey: @"adaptive_banner_width"];
+        NSNumber *adaptiveMaxHeight = [parameters.localExtraParameters al_numberForKey: @"inline_adaptive_banner_max_height"];
+        NSString *adaptiveSizeMessage = [NSString stringWithFormat: @"AdaptivePlacementMismatch:pid-%@ w-%@ maxh-%@",
+                                         placementId ?: @"unknown",
+                                         adaptiveWidth ?: @"unknown",
+                                         adaptiveMaxHeight ?: @"unknown"];
+        [VungleMediationLogger logError: nil :adaptiveSizeMessage];
+        
         [self userError: @"Please use a Vungle inline placement ID in order to use Vungle adaptive ads"];
         return NO;
     }
@@ -460,6 +479,7 @@ static MAAdapterInitializationStatus ALVungleIntializationStatus = NSIntegerMin;
     self.nativeAd = [[VungleNative alloc] initWithPlacementId: placementIdentifier];
     self.nativeAd.delegate = delegate;
     self.nativeAd.adOptionsPosition = NativeAdOptionsPositionTopRight;
+    self.nativeAd.adapterAdFormat = @"MANativeAdAdapter";
     [self.nativeAd load: bidResponse];
 }
 

--- a/Vungle/VungleAdapter/ALVungleMediationAdapter.m
+++ b/Vungle/VungleAdapter/ALVungleMediationAdapter.m
@@ -11,6 +11,8 @@
 
 #define ADAPTER_VERSION @"7.7.1.0"
 
+static NSString *const kALVungleAdaptiveBannerKey = @"adaptive_banner";
+
 @interface ALVungleMediationAdapterInterstitialAdDelegate : NSObject <VungleInterstitialDelegate>
 @property (nonatomic,   weak) ALVungleMediationAdapter *parentAdapter;
 @property (nonatomic, strong) id<MAInterstitialAdapterDelegate> delegate;
@@ -428,8 +430,8 @@ static MAAdapterInitializationStatus ALVungleIntializationStatus = NSIntegerMin;
 
 - (BOOL)isAdaptiveAdViewEnabledForParameters:(id<MAAdapterResponseParameters>)parameters
 {
-    BOOL isAdaptiveServerParams = [parameters.serverParameters al_boolForKey: @"adaptive_banner"];
-    BOOL isAdaptiveLocalParams = [parameters.localExtraParameters al_boolForKey: @"adaptive_banner"];
+    BOOL isAdaptiveServerParams = [parameters.serverParameters al_boolForKey: kALVungleAdaptiveBannerKey];
+    BOOL isAdaptiveLocalParams = [parameters.localExtraParameters al_boolForKey: kALVungleAdaptiveBannerKey];
     
     if ( !isAdaptiveServerParams && !isAdaptiveLocalParams ) {
         return NO;
@@ -448,8 +450,8 @@ static MAAdapterInitializationStatus ALVungleIntializationStatus = NSIntegerMin;
 
 - (void)logAdaptiveAdViewForBannerPlacement:(id<MAAdapterResponseParameters>)parameters adViewAd:(VungleBannerView *)adViewAd
 {
-    BOOL isAdaptiveServerParams = [parameters.serverParameters al_boolForKey: @"adaptive_banner"];
-    BOOL isAdaptiveLocalParams = [parameters.localExtraParameters al_boolForKey: @"adaptive_banner"];
+    BOOL isAdaptiveServerParams = [parameters.serverParameters al_boolForKey: kALVungleAdaptiveBannerKey];
+    BOOL isAdaptiveLocalParams = [parameters.localExtraParameters al_boolForKey: kALVungleAdaptiveBannerKey];
     BOOL isInlinePlacement = [VungleAds isInLine: parameters.thirdPartyAdPlacementIdentifier];
 
     if ( ( isAdaptiveServerParams || isAdaptiveLocalParams ) && !isInlinePlacement ) {

--- a/Vungle/VungleAdapter/ALVungleMediationAdapter.m
+++ b/Vungle/VungleAdapter/ALVungleMediationAdapter.m
@@ -389,7 +389,6 @@ static MAAdapterInitializationStatus ALVungleIntializationStatus = NSIntegerMin;
         self.adViewAd.adapterAdFormat = @"MAAdViewAdapter";
         [self logAdaptiveAdViewForBannerPlacement: parameters adViewAd:self.adViewAd];
 
-
         [self.adViewAd load: bidResponse];
     }
 }
@@ -459,10 +458,10 @@ static MAAdapterInitializationStatus ALVungleIntializationStatus = NSIntegerMin;
         // This is the case in which AdUnit is set to "adaptive", but Placement is not inline.
         NSNumber *adaptiveWidth = [parameters.localExtraParameters al_numberForKey: @"adaptive_banner_width"];
         NSNumber *adaptiveMaxHeight = [parameters.localExtraParameters al_numberForKey: @"inline_adaptive_banner_max_height"];
-        NSString *adaptiveSizeMessage = [NSString stringWithFormat: @"AdaptiveBannerSizeMismatch:w-%@|maxh-%@",
+        NSString *adaptiveSizeMismatchMessage = [NSString stringWithFormat: @"AdaptiveBannerSizeMismatch:w-%@|maxh-%@",
                                          adaptiveWidth ?: @"unknown",
                                          adaptiveMaxHeight ?: @"unknown"];
-        [VungleMediationLogger logErrorForAd:adViewAd message:adaptiveSizeMessage];
+        [VungleMediationLogger logErrorForAd:adViewAd message:adaptiveSizeMismatchMessage];
     }
 }
 

--- a/Vungle/VungleAdapter/ALVungleMediationAdapter.m
+++ b/Vungle/VungleAdapter/ALVungleMediationAdapter.m
@@ -444,11 +444,11 @@ static MAAdapterInitializationStatus ALVungleIntializationStatus = NSIntegerMin;
         NSString *placementId = parameters.thirdPartyAdPlacementIdentifier;
         NSNumber *adaptiveWidth = [parameters.localExtraParameters al_numberForKey: @"adaptive_banner_width"];
         NSNumber *adaptiveMaxHeight = [parameters.localExtraParameters al_numberForKey: @"inline_adaptive_banner_max_height"];
-        NSString *adaptiveSizeMessage = [NSString stringWithFormat: @"AdaptivePlacementMismatch:pid-%@ w-%@ maxh-%@",
+        NSString *adaptiveSizeMessage = [NSString stringWithFormat: @"AdaptiveBannerSizeMismatch:pid-%@|w-%@|maxh-%@",
                                          placementId ?: @"unknown",
                                          adaptiveWidth ?: @"unknown",
                                          adaptiveMaxHeight ?: @"unknown"];
-        [VungleMediationLogger logError: nil :adaptiveSizeMessage];
+        [VungleMediationLogger logErrorForAd:nil message:adaptiveSizeMessage];
         
         [self userError: @"Please use a Vungle inline placement ID in order to use Vungle adaptive ads"];
         return NO;


### PR DESCRIPTION
This commit will add 
- logging adaptive banner size mismatch through `VungleMediationLogger` introduced in 7.7.1.
- setting `adapterAdFormat` property in `basePublicAd`  introduced in 7.7.1.

[IOS-7623](https://vungle.atlassian.net/browse/IOS-7623)

[IOS-7623]: https://vungle.atlassian.net/browse/IOS-7623?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ