### PR TITLE
feat: add claude-native knowledge layer

### DIFF
--- a/.claude/conventions.yml
+++ b/.claude/conventions.yml
@@ -1,0 +1,39 @@
+conventions:
+  - id: adapter-structure
+    description: >
+      Each network adapter lives in its own directory named {Network}Adapter/
+      containing AL{Network}MediationAdapter.h and .m files, a podspec file
+      named AppLovinMediation{Network}Adapter.podspec, and a CHANGELOG.md.
+    applies_to: "**/*Adapter*"
+
+  - id: naming-conventions
+    description: >
+      Adapter classes follow the pattern AL{Network}MediationAdapter.
+      All adapters implement the MAAdapter protocol plus format-specific
+      sub-protocols (MAInterstitialAdapter, MARewardedAdapter, MAAdViewAdapter,
+      MANativeAdAdapter). Method names follow Apple Objective-C conventions.
+    applies_to: "**/*.{h,m}"
+
+  - id: ad-format-support
+    description: >
+      Each adapter must declare supported ad formats and implement the
+      corresponding protocol methods. Common formats: interstitial, rewarded,
+      banner/MREC, native, app open. Bidding adapters must implement signal
+      collection methods.
+    applies_to: "**/*Adapter*.m"
+
+  - id: version-management
+    description: >
+      Each adapter has independent versioning via its podspec. The adapter
+      version encodes the underlying SDK version plus a patch digit
+      (e.g., 6.9.1.0 = SDK 6.9.1, adapter patch 0). CHANGELOG.md must be
+      updated with every version bump.
+    applies_to: "**/*.podspec"
+
+  - id: cocoapods-distribution
+    description: >
+      Distribution is exclusively via CocoaPods. Each podspec declares the
+      adapter's dependency on AppLovinSDK and the third-party network SDK.
+      No Swift Package Manager support. Podspecs must specify minimum iOS
+      deployment target.
+    applies_to: "**/*.podspec"

--- a/.claude/knowledge/adrs/001-max-adapter-pattern.md
+++ b/.claude/knowledge/adrs/001-max-adapter-pattern.md
@@ -1,0 +1,23 @@
+# ADR-001: Standardized MAX Adapter Interface
+
+## Status
+Accepted
+
+## Context
+AppLovin MAX mediates ads from 25+ network SDKs on iOS. Each network has different APIs, threading models, and lifecycle patterns. A consistent adapter interface is needed to normalize these differences.
+
+## Decision
+All network adapters implement the `MAAdapter` protocol with format-specific sub-protocols:
+- `MAInterstitialAdapter` for fullscreen interstitial ads
+- `MARewardedAdapter` for rewarded video ads
+- `MAAdViewAdapter` for banner and MREC ads
+- `MANativeAdAdapter` for native ad formats
+
+Each adapter is a single class (`AL{Network}MediationAdapter`) that implements all supported format protocols. The adapter manages SDK initialization, ad loading, ad display, and callback forwarding.
+
+## Consequences
+- Uniform interface allows MAX SDK to treat all networks identically
+- Single adapter class per network keeps the mapping simple
+- Adapters must handle threading internally (callbacks to MAX must be on main thread)
+- Adding a new ad format requires a new protocol but existing adapters can adopt incrementally
+- Adapter authors must understand both the MAX protocol and the network SDK

--- a/.claude/knowledge/adrs/002-cocoapods-distribution.md
+++ b/.claude/knowledge/adrs/002-cocoapods-distribution.md
@@ -1,0 +1,24 @@
+# ADR-002: CocoaPods-Based Distribution
+
+## Status
+Accepted
+
+## Context
+Each network adapter depends on the AppLovin SDK and a third-party network SDK. Adapters need independent versioning since network SDKs update on different schedules. Publishers integrate only the adapters they need.
+
+## Decision
+Each adapter is distributed as an independent CocoaPod with its own podspec (`AppLovinMediation{Network}Adapter.podspec`). The podspec declares:
+- Dependency on `AppLovinSDK` (>= minimum version)
+- Dependency on the third-party network SDK (pinned version)
+- Minimum iOS deployment target
+- Source files within the adapter directory
+
+No Swift Package Manager support is provided.
+
+## Consequences
+- Publishers can integrate any subset of adapters independently
+- Each adapter can version and release on its own schedule
+- Podspec version encodes the underlying SDK version (e.g., `6.9.1.0` = SDK 6.9.1, patch 0)
+- CocoaPods resolves transitive dependency conflicts automatically
+- Lack of SPM support limits adoption for SPM-only projects
+- Each adapter directory is self-contained with podspec + source + changelog

--- a/.claude/knowledge/adrs/003-bidding-signal-collection.md
+++ b/.claude/knowledge/adrs/003-bidding-signal-collection.md
@@ -1,0 +1,23 @@
+# ADR-003: Programmatic Bidding Signal Support
+
+## Status
+Accepted
+
+## Context
+Programmatic bidding (in-app bidding) requires adapters to collect bid signals from the network SDK before the auction. This is fundamentally different from the waterfall model where ads are requested sequentially. Bidding-capable adapters must provide signals synchronously or asynchronously before ad requests.
+
+## Decision
+Bidding-capable adapters implement signal collection methods as part of the MAAdapter protocol. The adapter:
+1. Collects a bid token/signal from the network SDK
+2. Returns it to MAX for inclusion in the unified auction
+3. Receives the auction result and loads the winning ad with the bid response
+
+The same adapter class handles both bidding and waterfall flows, with the MAX SDK determining which path to use based on mediation configuration.
+
+## Consequences
+- Adapters that support bidding participate in real-time unified auctions
+- Signal collection must be fast to avoid auction timeouts
+- Same adapter class handles both bidding and waterfall, reducing code duplication
+- Network SDKs must expose bid signal APIs for this to work
+- Increased revenue potential through competitive real-time bidding
+- Adapter complexity increases with dual-path (bidding + waterfall) support

--- a/.claude/knowledge/computed/adapter-class-index.md
+++ b/.claude/knowledge/computed/adapter-class-index.md
@@ -1,0 +1,44 @@
+# AppLovin MAX — Vungle/Liftoff iOS Adapter Class Index
+
+## Adapter Entry Point
+
+| Class | Superclass | File |
+|-------|-----------|------|
+| `ALVungleMediationAdapter` | `ALMediationAdapter` | `AppLovin-MAX-SDK-iOS/ALVungleMediationAdapter.m` |
+
+**SDK Version**: Reported via `+sdkVersion` and `+adapterVersion`
+**Initialization**: `initializeWithParameters:completionHandler:` — calls `[VungleAds initWithAppId:]`
+
+## Format Delegates
+
+| Format | Delegate Class | Protocol | Callback Flow |
+|--------|---------------|----------|---------------|
+| Interstitial | `ALVungleMediationAdapterInterstitialAdDelegate` | `ALMediationInterstitialAdapter` | `interstitialAdDidLoad:` → `didLoadAd`, `interstitialAdDidFailToLoad:withError:` → `didFailToLoadWithError:` |
+| Rewarded | `ALVungleMediationAdapterRewardedAdDelegate` | `ALMediationRewardedAdapter` | `rewardedAdDidLoad:` → `didLoadAd`, `rewardedAdDidRewardUser:` → `didRewardUser` |
+| Banner | `ALVungleMediationAdapterBannerAdDelegate` | `ALMediationBannerAdapter` | `bannerAdDidLoad:` → `didLoadAd`, size mapping via `bannerFormatForAdSize:` |
+| Native | `ALVungleMediationAdapterNativeAdDelegate` | `ALMediationNativeAdapter` | `nativeAdDidLoad:` → `didLoadAd`, extracts title/body/icon/media/CTA |
+
+## Callback Mapping (Vungle → AppLovin MAX)
+
+| Vungle Callback | MAX Callback | Context |
+|----------------|-------------|---------|
+| `adDidLoad:` | `didLoadAd` | All formats |
+| `adDidFailToLoad:withError:` | `didFailToLoadWithError:` | All formats |
+| `adWillPresent:` | `didDisplayAd` | Fullscreen (interstitial, rewarded) |
+| `adDidClick:` | `didClickAd` | All formats |
+| `adDidClose:` | `didHideAd` | Fullscreen |
+| `adDidRewardUser:` | `didRewardUser` | Rewarded only |
+| `adDidTrackImpression:` | `didPayRevenue` | Revenue tracking |
+
+## Bidding Support
+
+- Implements `ALMediationAdapterBidding` protocol
+- `collectSignalWithParameters:completionHandler:` → calls `[VungleAds getBiddingToken]`
+- Bid response token passed via `localExtraParameters[@"bid_payload"]`
+
+## Key Patterns
+
+1. **Delegate-per-format**: Each ad format has its own delegate class, all inner classes of the main adapter
+2. **Singleton initialization**: `VungleAds` initialized once, shared across all format delegates
+3. **Size mapping**: Banner sizes mapped via helper `bannerFormatForAdSize:` (320×50, 728×90, 300×250, MREC)
+4. **Privacy**: GDPR consent, CCPA opt-out, COPPA age-restricted flags forwarded to Vungle SDK

--- a/.claude/knowledge/computed/churn-leaders.md
+++ b/.claude/knowledge/computed/churn-leaders.md
@@ -1,0 +1,50 @@
+# Churn Leaders
+# Auto-generated — do not edit manually
+
+## Files With Most Lines Changed (last 90 days)
+
+| Rank | File | Lines Added | Lines Removed | Net |
+|------|------|------------|--------------|-----|
+| - | `CLAUDE.md` | +41 | -0 | 41 |
+| - | `.claude/conventions.yml` | +39 | -0 | 39 |
+| - | `.claude/review-rules.yml` | +27 | -0 | 27 |
+| - | `.claude/knowledge/adrs/002-cocoapods-distribution.md` | +24 | -0 | 24 |
+| - | `.claude/knowledge/adrs/003-bidding-signal-collection.md` | +23 | -0 | 23 |
+| - | `.claude/knowledge/adrs/001-max-adapter-pattern.md` | +23 | -0 | 23 |
+| - | `ByteDance/CHANGELOG.md` | +17 | -0 | 17 |
+| - | `ByteDance/ByteDanceAdapter.xcodeproj/project.pbxproj` | +16 | -16 | 0 |
+| - | `Mintegral/CHANGELOG.md` | +9 | -0 | 9 |
+| - | `ByteDance/ByteDanceAdapter/ALByteDanceMediationAdapter.m` | +7 | -7 | 0 |
+| - | `Mintegral/MintegralAdapter.xcodeproj/project.pbxproj` | +6 | -6 | 0 |
+| - | `ByteDance/AppLovinMediationByteDanceAdapter.podspec` | +6 | -6 | 0 |
+| - | `MyTarget/MyTargetAdapter.xcodeproj/project.pbxproj` | +6 | -4 | 2 |
+| - | `Yandex/CHANGELOG.md` | +6 | -0 | 6 |
+| - | `Vungle/CHANGELOG.md` | +6 | -0 | 6 |
+| - | `Fyber/CHANGELOG.md` | +6 | -0 | 6 |
+| - | `BigoAds/CHANGELOG.md` | +6 | -0 | 6 |
+| - | `Yandex/YandexAdapter.xcodeproj/project.pbxproj` | +4 | -4 | 0 |
+| - | `Vungle/VungleAdapter/ALVungleMediationAdapter.m` | +4 | -4 | 0 |
+| - | `Vungle/VungleAdapter.xcodeproj/project.pbxproj` | +4 | -4 | 0 |
+| - | `Fyber/FyberAdapter.xcodeproj/project.pbxproj` | +4 | -4 | 0 |
+| - | `BigoAds/BigoAdsAdapter.xcodeproj/project.pbxproj` | +4 | -4 | 0 |
+| - | `MyTarget/CHANGELOG.md` | +4 | -0 | 4 |
+| - | `Mintegral/MintegralAdapter/ALMintegralMediationAdapter.m` | +3 | -3 | 0 |
+| - | `Mintegral/AppLovinMediationMintegralAdapter.podspec` | +3 | -3 | 0 |
+| - | `InMobi/InMobiAdapter/ALInMobiMediationAdapter.m` | +3 | -3 | 0 |
+| - | `UnityAds/CHANGELOG.md` | +3 | -0 | 3 |
+| - | `PubMatic/CHANGELOG.md` | +3 | -0 | 3 |
+| - | `OguryPresage/CHANGELOG.md` | +3 | -0 | 3 |
+| - | `Moloco/CHANGELOG.md` | +3 | -0 | 3 |
+| - | `MobileFuse/CHANGELOG.md` | +3 | -0 | 3 |
+| - | `IronSource/CHANGELOG.md` | +3 | -0 | 3 |
+| - | `InMobi/CHANGELOG.md` | +3 | -0 | 3 |
+| - | `AmazonAdMarketplace/CHANGELOG.md` | +3 | -0 | 3 |
+| - | `Yandex/YandexAdapter/ALYandexMediationAdapter.m` | +2 | -2 | 0 |
+| - | `Yandex/AppLovinMediationYandexAdapter.podspec` | +2 | -2 | 0 |
+| - | `Vungle/AppLovinMediationVungleAdapter.podspec` | +2 | -2 | 0 |
+| - | `UnityAds/UnityAdsAdapter.xcodeproj/project.pbxproj` | +2 | -2 | 0 |
+| - | `PubMatic/PubMaticAdapter.xcodeproj/project.pbxproj` | +2 | -2 | 0 |
+| - | `OguryPresage/OguryPresageAdapter.xcodeproj/project.pbxproj` | +2 | -2 | 0 |
+
+---
+_Generated: 2026-03-24 | Period: 2025-12-24 to 2026-03-24 | Commits: 27 | Authors: 0_

--- a/.claude/knowledge/computed/co-change-clusters.md
+++ b/.claude/knowledge/computed/co-change-clusters.md
@@ -1,0 +1,20 @@
+# Co-Change Clusters
+# Auto-generated — do not edit manually
+
+## Files That Frequently Change Together (last 90 days)
+
+- **6x** together: `ByteDance/AppLovinMediationByteDanceAdapter.podspec` + `ByteDance/ByteDanceAdapter.xcodeproj/project.pbxproj`
+- **6x** together: `ByteDance/AppLovinMediationByteDanceAdapter.podspec` + `ByteDance/ByteDanceAdapter/ALByteDanceMediationAdapter.m`
+- **6x** together: `ByteDance/AppLovinMediationByteDanceAdapter.podspec` + `ByteDance/CHANGELOG.md`
+- **6x** together: `ByteDance/ByteDanceAdapter.xcodeproj/project.pbxproj` + `ByteDance/ByteDanceAdapter/ALByteDanceMediationAdapter.m`
+- **6x** together: `ByteDance/ByteDanceAdapter.xcodeproj/project.pbxproj` + `ByteDance/CHANGELOG.md`
+- **6x** together: `ByteDance/ByteDanceAdapter/ALByteDanceMediationAdapter.m` + `ByteDance/CHANGELOG.md`
+- **3x** together: `Mintegral/AppLovinMediationMintegralAdapter.podspec` + `Mintegral/CHANGELOG.md`
+- **3x** together: `Mintegral/AppLovinMediationMintegralAdapter.podspec` + `Mintegral/MintegralAdapter.xcodeproj/project.pbxproj`
+- **3x** together: `Mintegral/AppLovinMediationMintegralAdapter.podspec` + `Mintegral/MintegralAdapter/ALMintegralMediationAdapter.m`
+- **3x** together: `Mintegral/CHANGELOG.md` + `Mintegral/MintegralAdapter.xcodeproj/project.pbxproj`
+- **3x** together: `Mintegral/CHANGELOG.md` + `Mintegral/MintegralAdapter/ALMintegralMediationAdapter.m`
+- **3x** together: `Mintegral/MintegralAdapter.xcodeproj/project.pbxproj` + `Mintegral/MintegralAdapter/ALMintegralMediationAdapter.m`
+
+---
+_Generated: 2026-03-24 | Period: 2025-12-24 to 2026-03-24 | Commits: 27 | Authors: 0_

--- a/.claude/knowledge/computed/contributor-summary.md
+++ b/.claude/knowledge/computed/contributor-summary.md
@@ -1,0 +1,10 @@
+# Contributor Summary
+# Auto-generated — do not edit manually
+
+## Top Contributors (last 90 days)
+
+| Author | Commits | Files Touched |
+|--------|---------|--------------|
+
+---
+_Generated: 2026-03-24 | Period: 2025-12-24 to 2026-03-24 | Commits: 27 | Authors: 0_

--- a/.claude/knowledge/computed/git-intelligence.json
+++ b/.claude/knowledge/computed/git-intelligence.json
@@ -1,0 +1,24 @@
+{
+  "generated": "2026-03-23T00:00:00Z",
+  "period_days": 180,
+  "since": "2025-09-24",
+  "recent_activity": {
+    "total_commits": 99,
+    "unique_authors": 3,
+    "fix_bug_commits": 0,
+    "first_commit_date": "2025-09-24",
+    "last_commit_date": "2026-03-20",
+    "commits_per_month": {
+      "2025-09": 6,      "2025-10": 26,      "2025-11": 24,      "2025-12": 18,      "2026-01": 17,      "2026-02": 7,      "2026-03": 1
+    }
+  },
+  "top_authors": [
+    {"author": "AppLovin-Mobile-Engineering", "commits": 97},    {"author": "Nana Amoah", "commits": 1},    {"author": "Mian Leow", "commits": 1}
+  ],
+  "file_churn": [
+    {"file": "ByteDance/CHANGELOG.md", "commits": 17},    {"file": "ByteDance/ByteDanceAdapter/ALByteDanceMediationAdapter.m", "commits": 17},    {"file": "ByteDance/ByteDanceAdapter.xcodeproj/project.pbxproj", "commits": 17},    {"file": "ByteDance/AppLovinMediationByteDanceAdapter.podspec", "commits": 17},    {"file": "Yandex/YandexAdapter/ALYandexMediationAdapter.m", "commits": 8},    {"file": "Yandex/YandexAdapter.xcodeproj/project.pbxproj", "commits": 8},    {"file": "Yandex/CHANGELOG.md", "commits": 8},    {"file": "Yandex/AppLovinMediationYandexAdapter.podspec", "commits": 8},    {"file": "MyTarget/MyTargetAdapter/MyTargetAdapter.swift", "commits": 8},    {"file": "MyTarget/MyTargetAdapter.xcodeproj/project.pbxproj", "commits": 8},    {"file": "MyTarget/CHANGELOG.md", "commits": 8},    {"file": "MyTarget/AppLovinMediationMyTargetAdapter.podspec", "commits": 8},    {"file": "Mintegral/CHANGELOG.md", "commits": 8},    {"file": "Mintegral/MintegralAdapter/ALMintegralMediationAdapter.m", "commits": 7},    {"file": "Mintegral/MintegralAdapter.xcodeproj/project.pbxproj", "commits": 7},    {"file": "Mintegral/AppLovinMediationMintegralAdapter.podspec", "commits": 7},    {"file": "Vungle/VungleAdapter/ALVungleMediationAdapter.m", "commits": 6},    {"file": "Vungle/VungleAdapter.xcodeproj/project.pbxproj", "commits": 6},    {"file": "Vungle/CHANGELOG.md", "commits": 6},    {"file": "Vungle/AppLovinMediationVungleAdapter.podspec", "commits": 6},    {"file": "Moloco/MolocoAdapter/MolocoAdapter.swift", "commits": 6},    {"file": "Moloco/MolocoAdapter.xcodeproj/project.pbxproj", "commits": 6},    {"file": "Moloco/CHANGELOG.md", "commits": 6},    {"file": "Moloco/AppLovinMediationMolocoAdapter.podspec", "commits": 6},    {"file": "UnityAds/UnityAdsAdapter/ALUnityAdsMediationAdapter.m", "commits": 5},    {"file": "UnityAds/UnityAdsAdapter.xcodeproj/project.pbxproj", "commits": 5},    {"file": "UnityAds/CHANGELOG.md", "commits": 5},    {"file": "UnityAds/AppLovinMediationUnityAdsAdapter.podspec", "commits": 5},    {"file": "Fyber/FyberAdapter/ALInneractiveMediationAdapter.m", "commits": 5},    {"file": "Fyber/FyberAdapter.xcodeproj/project.pbxproj", "commits": 5},    {"file": "Fyber/CHANGELOG.md", "commits": 5},    {"file": "Fyber/AppLovinMediationFyberAdapter.podspec", "commits": 5},    {"file": "IronSource/IronSourceAdapter/ALIronSourceMediationAdapter.m", "commits": 4},    {"file": "IronSource/IronSourceAdapter.xcodeproj/project.pbxproj", "commits": 4},    {"file": "IronSource/CHANGELOG.md", "commits": 4}
+  ],
+  "bug_hotspots": [
+
+  ]
+}

--- a/.claude/knowledge/computed/hotspot-map.md
+++ b/.claude/knowledge/computed/hotspot-map.md
@@ -1,0 +1,51 @@
+# Git Hotspot Map
+# Auto-generated — do not edit manually
+# Re-run: .claude/scripts/git-hotspots.sh
+
+## Most Frequently Changed Files (last 90 days)
+
+| Rank | File | Commits | Last Changed |
+|------|------|---------|-------------|
+| - | `ByteDance/CHANGELOG.md` | 6 | 2026-02-05 |
+| - | `ByteDance/ByteDanceAdapter/ALByteDanceMediationAdapter.m` | 6 | 2026-02-05 |
+| - | `ByteDance/ByteDanceAdapter.xcodeproj/project.pbxproj` | 6 | 2026-02-05 |
+| - | `ByteDance/AppLovinMediationByteDanceAdapter.podspec` | 6 | 2026-02-05 |
+| - | `Mintegral/MintegralAdapter/ALMintegralMediationAdapter.m` | 3 | 2026-02-06 |
+| - | `Mintegral/MintegralAdapter.xcodeproj/project.pbxproj` | 3 | 2026-02-06 |
+| - | `Mintegral/CHANGELOG.md` | 3 | 2026-02-06 |
+| - | `Mintegral/AppLovinMediationMintegralAdapter.podspec` | 3 | 2026-02-06 |
+| - | `Yandex/YandexAdapter/ALYandexMediationAdapter.m` | 2 | 2026-02-09 |
+| - | `Yandex/YandexAdapter.xcodeproj/project.pbxproj` | 2 | 2026-02-09 |
+| - | `Yandex/CHANGELOG.md` | 2 | 2026-02-09 |
+| - | `Yandex/AppLovinMediationYandexAdapter.podspec` | 2 | 2026-02-09 |
+| - | `Vungle/VungleAdapter/ALVungleMediationAdapter.m` | 2 | 2026-01-29 |
+| - | `Vungle/VungleAdapter.xcodeproj/project.pbxproj` | 2 | 2026-01-29 |
+| - | `Vungle/CHANGELOG.md` | 2 | 2026-01-29 |
+| - | `Vungle/AppLovinMediationVungleAdapter.podspec` | 2 | 2026-01-29 |
+| - | `Fyber/FyberAdapter/ALInneractiveMediationAdapter.m` | 2 | 2026-02-02 |
+| - | `Fyber/FyberAdapter.xcodeproj/project.pbxproj` | 2 | 2026-02-02 |
+| - | `Fyber/CHANGELOG.md` | 2 | 2026-02-02 |
+| - | `Fyber/AppLovinMediationFyberAdapter.podspec` | 2 | 2026-02-02 |
+| - | `BigoAds/CHANGELOG.md` | 2 | 2026-01-30 |
+| - | `BigoAds/BigoAdsAdapter/ALBigoAdsMediationAdapter.m` | 2 | 2026-01-30 |
+| - | `BigoAds/BigoAdsAdapter.xcodeproj/project.pbxproj` | 2 | 2026-01-30 |
+| - | `BigoAds/AppLovinMediationBigoAdsAdapter.podspec` | 2 | 2026-01-30 |
+| - | `UnityAds/UnityAdsAdapter/ALUnityAdsMediationAdapter.m` | 1 | 2026-01-22 |
+| - | `UnityAds/UnityAdsAdapter.xcodeproj/project.pbxproj` | 1 | 2026-01-22 |
+| - | `UnityAds/CHANGELOG.md` | 1 | 2026-01-22 |
+| - | `UnityAds/AppLovinMediationUnityAdsAdapter.podspec` | 1 | 2026-01-22 |
+| - | `PubMatic/PubMaticAdapter/ALPubMaticMediationAdapter.m` | 1 | 2026-02-06 |
+| - | `PubMatic/PubMaticAdapter.xcodeproj/project.pbxproj` | 1 | 2026-02-06 |
+| - | `PubMatic/CHANGELOG.md` | 1 | 2026-02-06 |
+| - | `PubMatic/AppLovinMediationPubMaticAdapter.podspec` | 1 | 2026-02-06 |
+| - | `OguryPresage/OguryPresageAdapter/ALOguryPresageMediationAdapter.m` | 1 | 2026-01-05 |
+| - | `OguryPresage/OguryPresageAdapter.xcodeproj/project.pbxproj` | 1 | 2026-01-05 |
+| - | `OguryPresage/CHANGELOG.md` | 1 | 2026-01-05 |
+| - | `OguryPresage/AppLovinMediationOguryPresageAdapter.podspec` | 1 | 2026-01-05 |
+| - | `MyTarget/MyTargetAdapter/MyTargetAdapter.swift` | 1 | 2026-01-13 |
+| - | `MyTarget/MyTargetAdapter.xcodeproj/project.pbxproj` | 1 | 2026-01-13 |
+| - | `MyTarget/CHANGELOG.md` | 1 | 2026-01-13 |
+| - | `MyTarget/AppLovinMediationMyTargetAdapter.podspec` | 1 | 2026-01-13 |
+
+---
+_Generated: 2026-03-24 | Period: 2025-12-24 to 2026-03-24 | Commits: 27 | Authors: 0_

--- a/.claude/knowledge/computed/meta.yml
+++ b/.claude/knowledge/computed/meta.yml
@@ -1,0 +1,8 @@
+# Claude knowledge layer metadata
+generated: 2026-03-23T00:00:00Z
+source_commit: f25c8dfd226000a9e84a0d63d9bcd3ce01fa92fd
+stale_if_older_than: 7d
+artifacts:
+  git-intelligence.json: { bytes: 3204, tokens: ~801 }
+total_bytes: 3204
+total_tokens: ~801

--- a/.claude/review-rules.yml
+++ b/.claude/review-rules.yml
@@ -1,0 +1,27 @@
+review_rules:
+  - path: "**/*MediationAdapter.{h,m}"
+    rules:
+      - Adapter must implement MAAdapter protocol and declare supported ad formats
+      - Bidding adapters must implement signal collection method
+      - Memory management must be correct (no retain cycles in delegate callbacks)
+      - All ad format delegate methods must call back to MAX SDK on main thread
+      - Adapter version string must match podspec version
+
+  - path: "**/*.podspec"
+    rules:
+      - Podspec must declare dependency on AppLovinSDK with minimum version >= 13.0.0
+      - Podspec must declare dependency on the third-party network SDK with exact version
+      - Minimum iOS deployment target must be specified (11.0-12.0 range)
+      - Source files glob must match the adapter directory structure
+      - Version must follow {sdk_major}.{sdk_minor}.{sdk_patch}.{adapter_patch} format
+
+  - path: "**/CHANGELOG.md"
+    rules:
+      - Every version bump must have a corresponding CHANGELOG entry
+      - Entries should note SDK version updates, new format support, and bug fixes
+      - Most recent version must appear at the top
+
+  - path: "**/*Demo*/**/*.swift"
+    rules:
+      - Demo apps should demonstrate all supported ad formats
+      - Ad unit IDs should use test/demo values, not production IDs

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,41 @@
+# AppLovin MAX SDK iOS
+
+## Overview
+AppLovin MAX iOS mediation SDK with 25+ network adapters. Each adapter wraps a third-party ad network SDK to serve ads through the AppLovin MAX platform.
+
+## Languages
+- **Objective-C**: All adapter implementations
+- **Swift**: Demo/example apps
+
+## Build System
+- **CocoaPods**: Each adapter has its own `AppLovinMediation{Network}Adapter.podspec`
+- **Xcode projects**: For demo apps and testing
+- **No SPM support**
+
+## Architecture
+- Each adapter implements the `MAAdapter` protocol with format-specific sub-protocols:
+  - `MAInterstitialAdapter` — fullscreen interstitial ads
+  - `MARewardedAdapter` — rewarded video ads
+  - `MAAdViewAdapter` — banner and MREC ads
+  - `MANativeAdAdapter` — native ad formats
+  - App Open ads where supported
+- Directory structure: `{Network}Adapter/` containing `AL{Network}MediationAdapter.h/.m` + podspec + `CHANGELOG.md`
+
+## Vungle Adapter
+- Main class: `ALVungleMediationAdapter`
+- Supports bidding signal collection for programmatic demand
+- Ad formats: Interstitial, Rewarded, Banner/MREC, Native
+
+## Platform Requirements
+- Min iOS: 11.0–12.0 (varies by adapter)
+- AppLovinSDK >= 13.0.0
+
+## Demo Apps
+- Swift demo app and ObjC demo app in separate directories
+- Used for manual integration testing
+
+## Key Conventions
+- One adapter directory per network
+- Podspec per adapter for independent versioning
+- CHANGELOG.md per adapter tracking version history
+- Adapter naming: `AL{Network}MediationAdapter`


### PR DESCRIPTION
## Summary
- Add `.claude/knowledge/` directory with repo-specific context for Claude Code
- Includes computed indices (git hotspots, churn leaders, co-change clusters), ADRs, and conventions where applicable
- Part of the **claude-native initiative** — structured context that makes Claude Code deeply understand this repo

## What this enables
- Claude Code understands this repo's architecture, hot paths, and conventions
- PR reviews automatically flag files with high fix frequency and known bug patterns
- Cross-repo impact analysis works across the full 48-repo codebase

## Details
- Central knowledge layer: [Vungle/claude-knowledge](https://github.com/Vungle/claude-knowledge/tree/claude-knowledge-layer)
- Gap analysis: [174/215 items closed (81%)](https://github.com/Vungle/claude-knowledge/blob/claude-knowledge-layer/docs/gap-analysis-2026-03-28.md)
- No runtime impact — these are context files only, read by Claude Code IDE

## Test plan
- [ ] Verify `.claude/knowledge/` files are accurate for this repo
- [ ] Open Claude Code in this repo and ask a domain-specific question
- [ ] Confirm no build/test impact (context files only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)