### PR TITLE
[IOS-8018] Adapter Logging Phase 2 items

### DIFF
--- a/Vungle/VungleAdapter/ALVungleMediationAdapter.m
+++ b/Vungle/VungleAdapter/ALVungleMediationAdapter.m
@@ -9,7 +9,7 @@
 #import "ALVungleMediationAdapter.h"
 #import <VungleAdsSDK/VungleAdsSDK.h>
 
-#define ADAPTER_VERSION @"7.7.1.0"
+#define ADAPTER_VERSION @"7.7.3.0"
 
 static NSString *const kALVungleAdaptiveBannerKey = @"adaptive_banner";
 

--- a/Vungle/VungleAdapter/ALVungleMediationAdapter.m
+++ b/Vungle/VungleAdapter/ALVungleMediationAdapter.m
@@ -208,14 +208,6 @@ static MAAdapterInitializationStatus ALVungleIntializationStatus = NSIntegerMin;
     NSString *placementIdentifier = parameters.thirdPartyAdPlacementIdentifier;
     [self log: @"Loading %@interstitial ad for placement: %@...", ( isBiddingAd ? @"bidding " : @"" ), placementIdentifier];
     
-    if ( [self shouldFailAdLoadWhenSDKNotInitialized: parameters] && ![VungleAds isInitialized] )
-    {
-        [self log: @"Vungle SDK not successfully initialized: failing interstitial ad load..."];
-        [delegate didFailToLoadInterstitialAdWithError: MAAdapterError.notInitialized];
-        
-        return;
-    }
-    
     [self updateUserPrivacySettingsForParameters: parameters];
     
     self.interstitialAd = [[VungleInterstitial alloc] initWithPlacementId: placementIdentifier];
@@ -243,14 +235,6 @@ static MAAdapterInitializationStatus ALVungleIntializationStatus = NSIntegerMin;
     NSString *placementIdentifier = parameters.thirdPartyAdPlacementIdentifier;
     [self log: @"Loading %@app open ad for placement: %@...", ( isBiddingAd ? @"bidding " : @"" ), placementIdentifier];
     
-    if ( [self shouldFailAdLoadWhenSDKNotInitialized: parameters] && ![VungleAds isInitialized] )
-    {
-        [self log: @"Vungle SDK not successfully initialized: failing app open ad load..."];
-        [delegate didFailToLoadAppOpenAdWithError: MAAdapterError.notInitialized];
-        
-        return;
-    }
-    
     [self updateUserPrivacySettingsForParameters: parameters];
     
     self.appOpenAdDelegate = [[ALVungleMediationAdapterAppOpenAdDelegate alloc] initWithParentAdapter: self andNotify: delegate];
@@ -277,14 +261,6 @@ static MAAdapterInitializationStatus ALVungleIntializationStatus = NSIntegerMin;
     BOOL isBiddingAd = [bidResponse al_isValidString];
     NSString *placementIdentifier = parameters.thirdPartyAdPlacementIdentifier;
     [self log: @"Loading %@rewarded ad for placement: %@...", ( isBiddingAd ? @"bidding " : @"" ), placementIdentifier];
-    
-    if ( [self shouldFailAdLoadWhenSDKNotInitialized: parameters] && ![VungleAds isInitialized] )
-    {
-        [self log: @"Vungle SDK not successfully initialized: failing rewarded ad load..."];
-        [delegate didFailToLoadRewardedAdWithError: MAAdapterError.notInitialized];
-        
-        return;
-    }
     
     [self updateUserPrivacySettingsForParameters: parameters];
     
@@ -319,14 +295,6 @@ static MAAdapterInitializationStatus ALVungleIntializationStatus = NSIntegerMin;
     BOOL isNative = [parameters.serverParameters al_boolForKey: @"is_native"];
     
     [self log: @"Loading %@%@%@ ad for placement: %@...", ( isBiddingAd ? @"bidding " : @"" ), ( isNative ? @"native " : @"" ), adFormatLabel, placementIdentifier];
-    
-    if ( [self shouldFailAdLoadWhenSDKNotInitialized: parameters] && ![VungleAds isInitialized] )
-    {
-        [self log: @"Vungle SDK not successfully initialized: failing %@ ad load...", adFormatLabel];
-        [delegate didFailToLoadAdViewAdWithError: MAAdapterError.notInitialized];
-        
-        return;
-    }
     
     [self updateUserPrivacySettingsForParameters: parameters];
     
@@ -375,14 +343,6 @@ static MAAdapterInitializationStatus ALVungleIntializationStatus = NSIntegerMin;
     
     [self log: @"Loading %@native ad for placement: %@...", ( isBiddingAd ? @"bidding " : @"" ), placementIdentifier];
     
-    if ( [self shouldFailAdLoadWhenSDKNotInitialized: parameters] && ![VungleAds isInitialized] )
-    {
-        [self log: @"Vungle SDK not successfully initialized: failing native ad load..."];
-        [delegate didFailToLoadNativeAdWithError: MAAdapterError.notInitialized];
-        
-        return;
-    }
-    
     [self updateUserPrivacySettingsForParameters: parameters];
     
     self.nativeAdDelegate = [[ALVungleMediationAdapterNativeAdDelegate alloc] initWithParentAdapter: self
@@ -392,11 +352,6 @@ static MAAdapterInitializationStatus ALVungleIntializationStatus = NSIntegerMin;
 }
 
 #pragma mark - Shared Methods
-
-- (BOOL)shouldFailAdLoadWhenSDKNotInitialized:(id<MAAdapterResponseParameters>)parameters
-{
-    return [parameters.serverParameters al_boolForKey: @"fail_ad_load_when_sdk_not_initialized" defaultValue: YES];
-}
 
 - (BOOL)isAdaptiveAdViewEnabledForParameters:(id<MAAdapterResponseParameters>)parameters
 {

--- a/Vungle/VungleAdapter/ALVungleMediationAdapter.m
+++ b/Vungle/VungleAdapter/ALVungleMediationAdapter.m
@@ -500,8 +500,13 @@ static MAAdapterInitializationStatus ALVungleIntializationStatus = NSIntegerMin;
 
 + (MAAdapterError *)toMaxError:(nullable NSError *)vungleError isAdPresentError:(BOOL)adPresentError
 {
-    if ( !vungleError ) return MAAdapterError.unspecified;
-    
+    if ( !vungleError )
+    {
+        [VungleMediationLogger logErrorForAd: nil
+                                     message: @"unspecifiedErrorCode:vungleError=nil"];
+        return MAAdapterError.unspecified;
+    }
+
     int vungleErrorCode = (int) vungleError.code;
     MAAdapterError *adapterError = MAAdapterError.unspecified;
     
@@ -592,7 +597,13 @@ static MAAdapterInitializationStatus ALVungleIntializationStatus = NSIntegerMin;
             adapterError = MAAdapterError.webViewError;
             break;
     }
-    
+
+    if ( adapterError == MAAdapterError.unspecified )
+    {
+        [VungleMediationLogger logErrorForAd: nil
+                                     message: [NSString stringWithFormat: @"unspecifiedErrorCode:%d", vungleErrorCode]];
+    }
+
     return [MAAdapterError errorWithAdapterError: adapterError
                         mediatedNetworkErrorCode: vungleErrorCode
                      mediatedNetworkErrorMessage: vungleError.localizedDescription];
@@ -981,10 +992,11 @@ static MAAdapterInitializationStatus ALVungleIntializationStatus = NSIntegerMin;
 
 - (void)nativeAdDidLoad:(VungleNative *)nativeAd
 {
-    if ( !nativeAd || self.parentAdapter.nativeAd != nativeAd )
+    if ( self.parentAdapter.nativeAd != nativeAd )
     {
         [self.parentAdapter log: @"Native %@ ad failed to load: no fill", self.adFormat];
         [self.delegate didFailToLoadAdViewAdWithError: MAAdapterError.noFill];
+        [VungleMediationLogger logErrorForAd:nativeAd message:@"nativeAdObjectMismatch"];
         
         return;
     }
@@ -1078,10 +1090,11 @@ static MAAdapterInitializationStatus ALVungleIntializationStatus = NSIntegerMin;
 
 - (void)nativeAdDidLoad:(VungleNative *)nativeAd
 {
-    if ( !nativeAd || self.parentAdapter.nativeAd != nativeAd )
+    if ( self.parentAdapter.nativeAd != nativeAd )
     {
         [self.parentAdapter log: @"Native ad failed to load: no fill"];
         [self.delegate didFailToLoadNativeAdWithError: MAAdapterError.noFill];
+        [VungleMediationLogger logErrorForAd:nativeAd message:@"nativeAdObjectMismatch"];
         
         return;
     }
@@ -1092,6 +1105,7 @@ static MAAdapterInitializationStatus ALVungleIntializationStatus = NSIntegerMin;
     {
         [self.parentAdapter e: @"Native ad (%@) does not have required assets.", nativeAd];
         [self.delegate didFailToLoadNativeAdWithError: MAAdapterError.missingRequiredNativeAdAssets];
+        [VungleMediationLogger logErrorForAd:nativeAd message:@"missingRequiredNativeAdAssets"];
         
         return;
     }

--- a/Vungle/VungleAdapter/ALVungleMediationAdapter.m
+++ b/Vungle/VungleAdapter/ALVungleMediationAdapter.m
@@ -228,20 +228,10 @@ static MAAdapterInitializationStatus ALVungleIntializationStatus = NSIntegerMin;
 
 - (void)showInterstitialAdForParameters:(id<MAAdapterResponseParameters>)parameters andNotify:(id<MAInterstitialAdapterDelegate>)delegate
 {
-    if ( [self.interstitialAd canPlayAd] )
-    {
-        [self log: @"Showing interstitial ad for placement: %@...", parameters.thirdPartyAdPlacementIdentifier];
-        
-        UIViewController *presentingViewController = parameters.presentingViewController ?: [ALUtils topViewControllerFromKeyWindow];
-        [self.interstitialAd presentWith: presentingViewController];
-    }
-    else
-    {
-        [self log: @"Failed to show interstitial ad: ad not ready"];
-        [delegate didFailToDisplayInterstitialAdWithError: [MAAdapterError errorWithAdapterError: MAAdapterError.adDisplayFailedError
-                                                                        mediatedNetworkErrorCode: MAAdapterError.adNotReady.code
-                                                                     mediatedNetworkErrorMessage: MAAdapterError.adNotReady.message]];
-    }
+    [self log: @"Showing interstitial ad for placement: %@...", parameters.thirdPartyAdPlacementIdentifier];
+    
+    UIViewController *presentingViewController = parameters.presentingViewController ?: [ALUtils topViewControllerFromKeyWindow];
+    [self.interstitialAd presentWith: presentingViewController];
 }
 
 #pragma mark - MAAppOpenAdapter Methods
@@ -273,20 +263,10 @@ static MAAdapterInitializationStatus ALVungleIntializationStatus = NSIntegerMin;
 
 - (void)showAppOpenAdForParameters:(id<MAAdapterResponseParameters>)parameters andNotify:(id<MAAppOpenAdapterDelegate>)delegate
 {
-    if ( [self.appOpenAd canPlayAd] )
-    {
-        [self log: @"Showing app open ad for placement: %@...", parameters.thirdPartyAdPlacementIdentifier];
-        
-        UIViewController *presentingViewController = parameters.presentingViewController ?: [ALUtils topViewControllerFromKeyWindow];
-        [self.appOpenAd presentWith: presentingViewController];
-    }
-    else
-    {
-        [self log: @"Failed to show app open ad: ad not ready"];
-        [delegate didFailToDisplayAppOpenAdWithError: [MAAdapterError errorWithAdapterError: MAAdapterError.adDisplayFailedError
-                                                                   mediatedNetworkErrorCode: MAAdapterError.adNotReady.code
-                                                                mediatedNetworkErrorMessage: MAAdapterError.adNotReady.message]];
-    }
+    [self log: @"Showing app open ad for placement: %@...", parameters.thirdPartyAdPlacementIdentifier];
+    
+    UIViewController *presentingViewController = parameters.presentingViewController ?: [ALUtils topViewControllerFromKeyWindow];
+    [self.appOpenAd presentWith: presentingViewController];
 }
 
 #pragma mark - MARewardedAdapter Methods
@@ -318,23 +298,13 @@ static MAAdapterInitializationStatus ALVungleIntializationStatus = NSIntegerMin;
 
 - (void)showRewardedAdForParameters:(id<MAAdapterResponseParameters>)parameters andNotify:(id<MARewardedAdapterDelegate>)delegate
 {
-    if ( [self.rewardedAd canPlayAd] )
-    {
-        [self log: @"Showing rewarded ad for placement: %@...", parameters.thirdPartyAdPlacementIdentifier];
-        
-        // Configure reward from server.
-        [self configureRewardForParameters: parameters];
-        
-        UIViewController *presentingViewController = parameters.presentingViewController ?: [ALUtils topViewControllerFromKeyWindow];
-        [self.rewardedAd presentWith: presentingViewController];
-    }
-    else
-    {
-        [self log: @"Failed to show rewarded ad: ad not ready"];
-        [delegate didFailToDisplayRewardedAdWithError: [MAAdapterError errorWithAdapterError: MAAdapterError.adDisplayFailedError
-                                                                    mediatedNetworkErrorCode: MAAdapterError.adNotReady.code
-                                                                 mediatedNetworkErrorMessage: MAAdapterError.adNotReady.message]];
-    }
+    [self log: @"Showing rewarded ad for placement: %@...", parameters.thirdPartyAdPlacementIdentifier];
+    
+    // Configure reward from server.
+    [self configureRewardForParameters: parameters];
+    
+    UIViewController *presentingViewController = parameters.presentingViewController ?: [ALUtils topViewControllerFromKeyWindow];
+    [self.rewardedAd presentWith: presentingViewController];
 }
 
 #pragma mark - MAAdViewAdapter Methods


### PR DESCRIPTION
This commit will update the adapter code to add adapter logging phase 2 cases:

[IOS-8018](https://vungle.atlassian.net/browse/IOS-8018)
- Removed `canPlayAd` check to proper logging by SDK

[IOS-8020](https://vungle.atlassian.net/browse/IOS-8020)
- Removed `SDK initialization` check to proper logging by SDK

[IOS-8022](https://vungle.atlassian.net/browse/IOS-8022)
- Log Native Ad object mismatch case

[IOS-8062](https://vungle.atlassian.net/browse/IOS-8062)
- Log `MAAdapterError.unspecified` case

[IOS-8018]: https://vungle.atlassian.net/browse/IOS-8018?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[IOS-8020]: https://vungle.atlassian.net/browse/IOS-8020?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[IOS-8022]: https://vungle.atlassian.net/browse/IOS-8022?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[IOS-8062]: https://vungle.atlassian.net/browse/IOS-8062?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ