### PR TITLE
Add shared MCP server configuration

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,32 +1,32 @@
 {
   "mcpServers": {
+    "atlassian": {
+      "type": "http",
+      "url": "https://mcp.atlassian.com/v1/mcp"
+    },
     "google-workspace": {
-      "type": "stdio",
-      "command": "npx",
       "args": [
         "-y",
         "github:gemini-cli-extensions/workspace",
         "--use-dot-names"
       ],
+      "command": "npx",
       "env": {
         "SSH_CONNECTION": ""
-      }
-    },
-    "atlassian": {
-      "type": "http",
-      "url": "https://mcp.atlassian.com/v1/mcp"
-    },
-    "slack": {
-      "type": "http",
-      "url": "https://mcp.slack.com/mcp",
-      "oauth": {
-        "clientId": "1601185624273.8899143856786",
-        "callbackPort": 3118
-      }
+      },
+      "type": "stdio"
     },
     "phoebe": {
       "type": "http",
       "url": "https://phoebe.ops.vungle.io/mcp"
+    },
+    "slack": {
+      "oauth": {
+        "callbackPort": 3118,
+        "clientId": "1601185624273.8899143856786"
+      },
+      "type": "http",
+      "url": "https://mcp.slack.com/mcp"
     }
   }
 }

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,32 @@
+{
+  "mcpServers": {
+    "google-workspace": {
+      "type": "stdio",
+      "command": "npx",
+      "args": [
+        "-y",
+        "github:gemini-cli-extensions/workspace",
+        "--use-dot-names"
+      ],
+      "env": {
+        "SSH_CONNECTION": ""
+      }
+    },
+    "atlassian": {
+      "type": "http",
+      "url": "https://mcp.atlassian.com/v1/mcp"
+    },
+    "slack": {
+      "type": "http",
+      "url": "https://mcp.slack.com/mcp",
+      "oauth": {
+        "clientId": "1601185624273.8899143856786",
+        "callbackPort": 3118
+      }
+    },
+    "phoebe": {
+      "type": "http",
+      "url": "https://phoebe.ops.vungle.io/mcp"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Merge the shared Claude Code MCP servers into the repo-local `.mcp.json`.

## MCP servers added or updated

- `google-workspace`
- `atlassian`
- `slack`
- `phoebe`

## Notes

- Preserves any existing MCP servers already configured in this repository.
- Updates matching entries for the four shared servers to the agreed configuration.
- Does not change application code.